### PR TITLE
Replace header text with isotipo and center hero logo

### DIFF
--- a/charms.html
+++ b/charms.html
@@ -11,7 +11,9 @@
 <body>
   <header class="header">
     <div class="nav-container">
-      <a href="index.html"><img src="img/logotipo.png" alt="Auren" class="logo"></a>
+      <a href="index.html" class="brand">
+        <img src="img/isotipo.png" alt="Auren" class="logo-header">
+      </a>
       <nav>
         <ul class="nav-links">
           <li><a href="ropa.html">Ropa</a></li>

--- a/firstdate.html
+++ b/firstdate.html
@@ -11,7 +11,9 @@
 <body>
   <header class="header">
     <div class="nav-container">
-      <a href="index.html"><img src="img/logotipo.png" alt="Auren" class="logo"></a>
+      <a href="index.html" class="brand">
+        <img src="img/isotipo.png" alt="Auren" class="logo-header">
+      </a>
       <nav>
         <ul class="nav-links">
           <li><a href="ropa.html">Ropa</a></li>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,9 @@
 <body>
   <header class="header">
     <div class="nav-container">
-      <a href="index.html"><img src="img/logotipo.png" alt="Auren" class="logo"></a>
+      <a href="index.html" class="brand">
+        <img src="img/isotipo.png" alt="Auren" class="logo-header">
+      </a>
       <nav>
         <ul class="nav-links">
           <li><a href="ropa.html">Ropa</a></li>
@@ -26,7 +28,7 @@
 
   <section class="hero">
     <div class="hero-content">
-      <h2>Auren</h2>
+      <img src="img/logotipo.png" alt="Auren" class="logo-hero">
       <p>Arturo y Enrique crean momentos inolvidables para enamorar.</p>
     </div>
   </section>

--- a/joyeria.html
+++ b/joyeria.html
@@ -11,7 +11,9 @@
 <body>
   <header class="header">
     <div class="nav-container">
-      <a href="index.html"><img src="img/logotipo.png" alt="Auren" class="logo"></a>
+      <a href="index.html" class="brand">
+        <img src="img/isotipo.png" alt="Auren" class="logo-header">
+      </a>
       <nav>
         <ul class="nav-links">
           <li><a href="ropa.html">Ropa</a></li>

--- a/ropa.html
+++ b/ropa.html
@@ -11,7 +11,9 @@
 <body>
   <header class="header">
     <div class="nav-container">
-      <a href="index.html"><img src="img/logotipo.png" alt="Auren" class="logo"></a>
+      <a href="index.html" class="brand">
+        <img src="img/isotipo.png" alt="Auren" class="logo-header">
+      </a>
       <nav>
         <ul class="nav-links">
           <li><a href="ropa.html">Ropa</a></li>

--- a/style.css
+++ b/style.css
@@ -48,10 +48,11 @@ a { text-decoration:none; color:inherit; }
   padding:10px 20px;
 }
 
-.logo {
-  height:48px;
+.logo-header {
+  height:40px;
   width:auto;
   display:block;
+  filter:drop-shadow(0 2px 2px rgba(0,0,0,.4));
 }
 .nav-links {
   list-style:none;
@@ -81,7 +82,7 @@ a { text-decoration:none; color:inherit; }
     background:var(--dark);
     flex-direction:column;
     padding:20px;
-    border:1px solid var(--pink);
+    border:1px solid var(--light);
   }
   .nav-links.open { display:flex; }
   .hamburger { display:block; }
@@ -109,9 +110,16 @@ a { text-decoration:none; color:inherit; }
 
 .hero-content { position:relative; }
 
-.hero-content h2 {
-  font-size:3rem;
-  color:var(--light);
+.logo-hero {
+  height:120px;
+  width:auto;
+  display:block;
+  margin:0 auto;
+  filter:drop-shadow(0 2px 2px rgba(0,0,0,.4));
+}
+
+@media(max-width:768px){
+  .logo-hero { height:80px; }
 }
 
 /* Intro */


### PR DESCRIPTION
## Summary
- swap header text logo for isotipo image across all pages and size it to 40px with drop-shadow
- replace hero title with centered logotipo image responsive at 120/80px and drop-shadow for contrast
- remove outdated red header accents by changing mobile nav border to white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb81c1067c832188457d140102f1d6