### PR TITLE
feat: enhance bracelet builder animations

### DIFF
--- a/builder.css
+++ b/builder.css
@@ -37,6 +37,7 @@
   border-radius: 999px;
   padding: .25rem .75rem;
   cursor: pointer;
+  transition: all .2s ease;
 }
 
 .catalog-grid {
@@ -57,6 +58,7 @@
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
   text-align: center;
   padding-bottom: .5rem;
+  transition: all .2s ease;
 }
 
 .charm-card img {
@@ -77,6 +79,7 @@
   padding: .25rem .5rem;
   border-radius: .25rem;
   cursor: pointer;
+  transition: all .2s ease;
 }
 
 .bracelet-grid {
@@ -97,6 +100,7 @@
   justify-content: center;
   font-size: .75rem;
   color: var(--suave);
+  transition: all .2s ease;
 }
 
 .slot.filled {
@@ -122,6 +126,7 @@
   border-radius: 50%;
   cursor: pointer;
   font-size: .7rem;
+  transition: all .2s ease;
 }
 
 .builder-bar {
@@ -142,10 +147,42 @@
   background: var(--acento);
   color: #fff;
   cursor: pointer;
+  transition: all .2s ease;
 }
 
 .builder-bar button.whatsapp {
   background: var(--green);
+}
+
+/* Hover shadows */
+.charm-card:hover,
+.chips button:hover,
+.charm-card button:hover,
+.builder-bar button:hover,
+.slot button.remove:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+/* Fade-in animation for catalogs and slots */
+.fade-in {
+  opacity: 0;
+  transform: translateY(10px);
+  animation: fade-in .4s forwards;
+}
+
+@keyframes fade-in {
+  to { opacity:1; transform:translateY(0); }
+}
+
+/* Snap animation when dropping charms */
+.slot.snap {
+  animation: snap .15s ease-out;
+}
+
+@keyframes snap {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.1); }
+  100% { transform: scale(1); }
 }
 
 @media(max-width:768px){

--- a/builder.js
+++ b/builder.js
@@ -119,8 +119,9 @@ function renderCatalog(){
   }
   const catalog=document.getElementById('catalog');
   catalog.innerHTML='';
-  list.forEach(c=>{
-    const card=document.createElement('div');card.className='charm-card';card.draggable=true;card.dataset.id=c.id;
+  list.forEach((c,i)=>{
+    const card=document.createElement('div');card.className='charm-card fade-in';card.draggable=true;card.dataset.id=c.id;
+    card.style.animationDelay=`${i*50}ms`;
     card.innerHTML=`<img src="${c.imgFront}" alt="${c.name} frente" class="front"><img src="${c.imgBack}" alt="${c.name} reverso" class="back"><h4>${c.name}</h4><p class="price">$${c.price}</p>${c.badge?`<span class="badge">${c.badge}</span>`:''}<button class="add">Agregar</button>`;
     card.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/plain',c.id);});
     card.querySelector('.add').addEventListener('click',()=>addCharm(c.id));
@@ -134,7 +135,8 @@ function renderBracelet(){
   container.innerHTML='';
   for(let i=0;i<braceletSize;i++){
     const slot=document.createElement('div');
-    slot.className='slot';
+    slot.className='slot fade-in';
+    slot.style.animationDelay=`${i*50}ms`;
     slot.dataset.index=i;
     slot.textContent=String(i+1).padStart(2,'0');
     slot.addEventListener('dragover',e=>e.preventDefault());
@@ -151,6 +153,14 @@ function renderBracelet(){
   }
 }
 
+function triggerSnap(index){
+  const el=document.querySelector(`.slot[data-index="${index}"]`);
+  if(el){
+    el.classList.add('snap');
+    setTimeout(()=>el.classList.remove('snap'),200);
+  }
+}
+
 function handleDrop(e){
   e.preventDefault();
   const targetIndex=parseInt(e.currentTarget.dataset.index,10);
@@ -160,12 +170,14 @@ function handleDrop(e){
     const from=parseInt(fromSlot,10);
     if(slots[targetIndex] && !e.shiftKey){
       swapSlots(from,targetIndex);
+      triggerSnap(targetIndex);
     }else{
       slots[targetIndex]=slots[from];
       slots[from]=null;
       pushState();
       renderBracelet();
       updateTotals();
+      triggerSnap(targetIndex);
     }
   }else if(charmId){
     if(slots[targetIndex] && !e.shiftKey){
@@ -179,6 +191,7 @@ function handleDrop(e){
     pushState();
     renderBracelet();
     updateTotals();
+    triggerSnap(targetIndex);
   }
 }
 


### PR DESCRIPTION
## Summary
- add 200ms transitions and soft hover shadows to charms, buttons, and slots
- show snap effect when dropping charms on bracelet
- fade in catalog and bracelet slots sequentially on load

## Testing
- `node --check builder.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbd342158832196d8c7c0549ec265