### PR TITLE
Improve mobile bracelet builder for small screens

### DIFF
--- a/builder.css
+++ b/builder.css
@@ -7,6 +7,18 @@
   margin-top: 2rem;
 }
 
+.filter-toggle {
+  display: none;
+  padding: .5rem 1rem;
+  border: none;
+  background: var(--acento);
+  color: #fff;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.filter-overlay { display: none; }
+
 .filters,
 .tray,
 .bracelet-area {
@@ -190,4 +202,32 @@
   .filters { order:3; }
   .tray { order:2; }
   .bracelet-area { order:1; }
+
+  .filter-toggle { display:block; margin:1rem auto; }
+  .filters {
+    position: fixed;
+    top:0; left:0; bottom:0;
+    width:80%;
+    max-width:300px;
+    transform:translateX(-100%);
+    transition:transform .3s ease;
+    z-index:1001;
+    overflow-y:auto;
+  }
+  .filters.open { transform:translateX(0); }
+  .filter-overlay {
+    position:fixed;
+    inset:0;
+    background:rgba(0,0,0,.4);
+    z-index:1000;
+  }
+  .filter-overlay.open { display:block; }
+}
+
+@media(max-width:480px){
+  .catalog-grid { grid-template-columns: repeat(auto-fill, minmax(140px,1fr)); }
+  .charm-card { font-size:.9rem; }
+  .charm-card button { font-size:.85rem; }
+  .bracelet-grid { grid-template-columns: repeat(auto-fill, minmax(80px,1fr)); }
+  .slot { width:80px; height:80px; }
 }

--- a/builder.html
+++ b/builder.html
@@ -32,6 +32,7 @@
       <img src="img/logotipo.png" alt="Auren logotipo" class="logo-hero">
     </div>
   </section>
+  <button id="filter-toggle" class="filter-toggle">Filtros</button>
 
   <main class="builder container">
     <aside class="filters">
@@ -77,6 +78,8 @@
       <p id="bracelet-total" class="price"></p>
     </aside>
   </main>
+
+  <div id="filter-overlay" class="filter-overlay"></div>
 
   <div class="builder-bar">
     <button id="undo" aria-label="Deshacer">Deshacer</button>

--- a/builder.js
+++ b/builder.js
@@ -148,6 +148,17 @@ function renderBracelet(){
       const rm=document.createElement('button');rm.className='remove';rm.textContent='x';rm.addEventListener('click',()=>removeCharm(i));slot.appendChild(rm);
       slot.draggable=true;
       slot.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/slot',i);});
+      let startX=null;
+      slot.addEventListener('touchstart',e=>{startX=e.touches[0].clientX;});
+      slot.addEventListener('touchend',e=>{
+        if(startX===null) return;
+        const dx=e.changedTouches[0].clientX-startX;
+        if(Math.abs(dx)>30){
+          if(dx<0 && i<braceletSize-1) swapSlots(i,i+1);
+          else if(dx>0 && i>0) swapSlots(i,i-1);
+        }
+        startX=null;
+      });
     }
     container.appendChild(slot);
   }
@@ -272,6 +283,21 @@ window.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('save').addEventListener('click',saveLocal);
   document.getElementById('load').addEventListener('click',loadLocal);
   document.getElementById('whatsapp').addEventListener('click',sendWhatsApp);
+  const filterToggle=document.getElementById('filter-toggle');
+  const filters=document.querySelector('.filters');
+  const overlay=document.getElementById('filter-overlay');
+  if(filterToggle){
+    filterToggle.addEventListener('click',()=>{
+      filters.classList.toggle('open');
+      overlay.classList.toggle('open');
+    });
+  }
+  if(overlay){
+    overlay.addEventListener('click',()=>{
+      filters.classList.remove('open');
+      overlay.classList.remove('open');
+    });
+  }
   const qs=new URLSearchParams(location.search).get('design');
   if(qs){const obj=decodeDesign(qs);if(obj){braceletSize=obj.size;slots=obj.slots;}}
   else { loadLocal(); }


### PR DESCRIPTION
## Summary
- Add sliding filter panel with toggle button and overlay for mobile
- Increase slot and card sizes and support swipe reordering
- Adjust catalog and slot layouts for better touch usability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc2639ac48321b1f677ed983f91ba