### PR TITLE
Add mock design image download to bracelet builder

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -85,10 +85,11 @@
     <button id="undo" aria-label="Deshacer">Deshacer</button>
     <button id="redo" aria-label="Rehacer">Rehacer</button>
     <button id="clear" aria-label="Vaciar">Vaciar</button>
-    <button id="save" aria-label="Guardar">Guardar</button>
-    <button id="load" aria-label="Cargar">Cargar</button>
-    <button id="whatsapp" aria-label="Pedir por WhatsApp" class="whatsapp">Pedir por WhatsApp</button>
-  </div>
+      <button id="save" aria-label="Guardar">Guardar</button>
+      <button id="load" aria-label="Cargar">Cargar</button>
+      <button id="download" aria-label="Descargar imagen del diseño (mock)">Descargar imagen del diseño (mock)</button>
+      <button id="whatsapp" aria-label="Pedir por WhatsApp" class="whatsapp">Pedir por WhatsApp</button>
+    </div>
 
   <footer class="footer">
     <div class="container">

--- a/builder.js
+++ b/builder.js
@@ -249,6 +249,43 @@ function sendWhatsApp(){
   window.open(`https://wa.me/523142836428?text=${msg}`,'_blank');
 }
 
+// Descargar imagen del diseño
+async function downloadMock(){
+  const filled=slots.filter(Boolean);
+  if(!filled.length){
+    alert('No hay charms en tu diseño');
+    return;
+  }
+  const cell=100;
+  const cols=6;
+  const rows=Math.ceil(filled.length/cols);
+  const canvas=document.createElement('canvas');
+  canvas.width=cols*cell;
+  canvas.height=rows*cell;
+  const ctx=canvas.getContext('2d');
+
+  const images=await Promise.all(filled.map(id=>{
+    const c=charms.find(ch=>ch.id===id);
+    return new Promise((resolve,reject)=>{
+      const img=new Image();
+      img.onload=()=>resolve(img);
+      img.onerror=reject;
+      img.src=c.imgFront;
+    });
+  }));
+
+  images.forEach((img,i)=>{
+    const x=(i%cols)*cell;
+    const y=Math.floor(i/cols)*cell;
+    ctx.drawImage(img,x,y,cell,cell);
+  });
+
+  const link=document.createElement('a');
+  link.href=canvas.toDataURL('image/png');
+  link.download='pulsera-mock.png';
+  link.click();
+}
+
 // Undo/redo
 function undo(){
   if(undoStack.length){
@@ -282,6 +319,7 @@ window.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('clear').addEventListener('click',()=>{if(confirm('¿Vaciar pulsera?')){slots=Array(braceletSize).fill(null);pushState();renderBracelet();updateTotals();}});
   document.getElementById('save').addEventListener('click',saveLocal);
   document.getElementById('load').addEventListener('click',loadLocal);
+  document.getElementById('download').addEventListener('click',downloadMock);
   document.getElementById('whatsapp').addEventListener('click',sendWhatsApp);
   const filterToggle=document.getElementById('filter-toggle');
   const filters=document.querySelector('.filters');


### PR DESCRIPTION
## Summary
- add “Descargar imagen del diseño (mock)” button to builder toolbar
- render filled bracelet slots on an off-screen canvas and export as PNG

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc36c96108321965f204ae7c45590