### PR TITLE
feat: add charm discounts and promo banner

### DIFF
--- a/builder.html
+++ b/builder.html
@@ -12,6 +12,7 @@
 </head>
 <body id="bracelet-builder">
   <header class="header">
+    <div class="promo-banner"><a href="builder.html">🎁 Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</a></div>
     <div class="nav-container container">
       <a href="index.html" class="brand"><img src="img/isotipo.png" alt="Auren" class="logo-header"></a>
       <nav>
@@ -43,8 +44,8 @@
       <div id="filter-material" class="chips"></div>
       <div class="price-range">
         <label>Precio: <span id="price-display"></span></label>
-        <input type="range" id="price-min" min="0" max="500" value="0">
-        <input type="range" id="price-max" min="0" max="500" value="500">
+        <input type="range" id="price-min" min="30" max="125" value="30">
+        <input type="range" id="price-max" min="30" max="125" value="125">
       </div>
       <div class="size-select">
         <label for="size">Eslabones:</label>
@@ -76,6 +77,7 @@
       <div id="bracelet" class="bracelet-grid" aria-live="polite"></div>
       <p id="bracelet-status"></p>
       <p id="bracelet-total" class="price"></p>
+      <p id="bracelet-promo" class="promo-note"></p>
     </aside>
   </main>
 

--- a/builder.js
+++ b/builder.js
@@ -1,20 +1,5 @@
 // Constructor de Pulsera Italiana
-// Data de ejemplo de charms
-const charms = [];
-for (let i = 1; i <= 30; i++) {
-  charms.push({
-    id: `id-${String(i).padStart(3,'0')}`,
-    name: `Charm ${i}`,
-    price: 100 + i * 5,
-    tags: i % 2 ? ['amor'] : ['amistad'],
-    imgFront: `img/charms/charm-${String(i).padStart(2,'0')}.jpg`,
-    imgBack: `img/charms/charm-${String(i).padStart(2,'0')}b.jpg`,
-    color: ['rosa','azul','dorado'][i%3],
-    material: ['acero','oro','plata'][i%3],
-    stock: i % 6 === 0 ? 0 : 10,
-    badge: i % 10 === 0 ? '-20%' : i % 5 === 0 ? 'Nuevo' : i % 7 === 0 ? 'Top' : ''
-  });
-}
+const charms = charmsCatalog;
 
 let braceletSize = 18;
 let slots = Array(braceletSize).fill(null);
@@ -126,7 +111,8 @@ function renderCatalog(){
     const card=document.createElement('div');card.className='charm-card fade-in';card.dataset.id=c.id;
     if(out) card.classList.add('out'); else card.draggable=true;
     card.style.animationDelay=`${i*50}ms`;
-    card.innerHTML=`<img src="${c.imgFront}" alt="${c.name} frente" class="front"><img src="${c.imgBack}" alt="${c.name} reverso" class="back"><h4>${c.name}</h4><p class="price">$${c.price}</p>${c.badge?`<span class="badge">${c.badge}</span>`:''}${out?`<span class="badge agotado">Agotado</span>`:''}<button class="add"${out?' disabled':''}>Agregar</button>`;
+    const priceHTML=`<div class="price"><span class="price-old">$${c.priceOriginal}</span><span class="price-new">$${c.price}</span></div>`;
+    card.innerHTML=`<img src="${c.imgFront}" alt="${c.name} frente" class="front"><img src="${c.imgBack}" alt="${c.name} reverso" class="back"><h4>${c.name}</h4>${priceHTML}${c.badge?`<span class="badge badge-descuento">${c.badge}</span>`:''}${out?`<span class="badge agotado">Agotado</span>`:''}<button class="add"${out?' disabled':''}>Agregar</button>`;
     if(!out){
       card.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/plain',c.id);});
       card.querySelector('.add').addEventListener('click',()=>addCharm(c.id));
@@ -223,6 +209,8 @@ function updateTotals(){
   const total=filled.reduce((s,id)=>s+(charms.find(c=>c.id===id)?.price||0),0);
   document.getElementById('bracelet-total').textContent=`Total: $${total}`;
   document.getElementById('bracelet-status').textContent=`${filled.length}/${braceletSize} completos`;
+  const promo=document.getElementById('bracelet-promo');
+  if(promo){promo.textContent=total>=400?'Pulsera incluida GRATIS':'';}
 }
 
 function saveLocal(){
@@ -257,7 +245,8 @@ function updatePersist(){
 function sendWhatsApp(){
   const filled=slots.map((id,i)=>{ if(!id) return null; const c=charms.find(ch=>ch.id===id); return `${String(i+1).padStart(2,'0')}) [${c.id}] ${c.name} – $${c.price}`;}).filter(Boolean).join('%0A');
   const total=slots.filter(Boolean).reduce((s,id)=>s+(charms.find(c=>c.id===id)?.price||0),0);
-  const msg=`Hola Auren, quiero esta pulsera italiana:%0AEslabones: ${braceletSize}%0A${filled}%0ATotal: $${total}%0A¿La pueden armar y enviarme opciones de pago, por favor? ❤️`;
+  const promo=total>=400? '%0APromo aplicada: pulsera GRATIS por compra >= $400 en charms. ✅':'';
+  const msg=`Hola Auren, quiero esta pulsera italiana:%0AEslabones: ${braceletSize}%0A${filled}%0ASubtotal charms: $${total}${promo}%0ATotal a pagar: $${total}%0A¿Opciones de pago, por favor?`;
   window.open(`https://wa.me/523142836428?text=${msg}`,'_blank');
 }
 

--- a/charms.html
+++ b/charms.html
@@ -14,6 +14,7 @@
 </head>
 <body data-category="charms">
   <header class="header">
+    <div class="promo-banner"><a href="builder.html">🎁 Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</a></div>
     <div class="nav-container container">
       <a href="index.html" class="brand"><img src="img/isotipo.png" alt="Auren" class="logo-header"></a>
       <nav>
@@ -53,8 +54,8 @@
         <span class="chip" data-tag="estrella">Estrella</span>
       </div>
       <h4>Precio</h4>
-      <input type="range" id="price" min="0" max="500" value="500">
-      <div class="price-output">$0 - $<span id="price-value">500</span></div>
+      <input type="range" id="price" min="30" max="125" value="125">
+      <div class="price-output">$30 - $<span id="price-value">125</span></div>
       <label><input type="checkbox" id="available"> Disponible</label>
     </aside>
     <section class="catalog-content">

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 </head>
 <body>
   <header class="header">
+    <div class="promo-banner"><a href="builder.html">🎁 Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</a></div>
     <div class="nav-container container">
       <a href="index.html" class="brand"><img src="img/isotipo.png" alt="Auren" class="logo-header"></a>
       <nav>

--- a/producto.html
+++ b/producto.html
@@ -14,6 +14,7 @@
 </head>
 <body id="product-detail">
   <header class="header">
+    <div class="promo-banner"><a href="builder.html">🎁 Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</a></div>
     <div class="nav-container container">
       <a href="index.html" class="brand"><img src="img/isotipo.png" alt="Auren" class="logo-header"></a>
       <nav>
@@ -37,7 +38,7 @@
     <div class="product-info">
       <h1 id="product-title"></h1>
       <p id="product-sku" class="num"></p>
-      <p class="price" id="product-price"></p>
+      <div id="product-price" class="price"></div>
       <div class="rating" id="product-rating" aria-label="rating">★★★★★</div>
       <div class="variants" id="variants"></div>
       <label for="qty">Cantidad</label>

--- a/style.css
+++ b/style.css
@@ -50,6 +50,13 @@ a:hover { color:var(--acento); }
 .chip{display:inline-block;padding:4px 12px;border-radius:16px;border:1px solid var(--acento);background:var(--fondo);cursor:pointer;font-size:.875rem;transition:.3s;margin:4px;}
 .chip.active,.chip:hover{background:var(--acento);color:var(--fondo);}
 .badge{position:absolute;top:8px;left:8px;background:var(--principal);color:var(--fondo);padding:2px 8px;border-radius:8px;font-size:.75rem;}
+.badge-descuento{background:var(--acento,#D6A77A);color:#111;font-weight:700;padding:2px 8px;border-radius:999px;}
+.price{display:flex;gap:8px;align-items:center;}
+.price-old{text-decoration:line-through;opacity:.6;}
+.price-new{font-weight:800;font-size:1.1em;}
+.promo-banner{background:var(--acento,#D6A77A);color:#111;text-align:center;padding:4px 10px;font-weight:700;font-size:.9rem;}
+.promo-banner a{color:#111;text-decoration:underline;}
+.promo-note{color:var(--principal);font-weight:700;}
 .card{position:relative;background:rgba(255,247,242,.8);border:1px solid var(--suave);border-radius:16px;overflow:hidden;box-shadow:0 4px 10px rgba(0,0,0,.08);transition:transform .3s;}
 .card:hover{transform:translateY(-4px);}
 .card .img-wrapper{position:relative;overflow:hidden;}


### PR DESCRIPTION
## Summary
- add generated 30-item charms catalog with discounts and pricing utilities
- show discount prices and global promo banner across pages
- update builder with free bracelet promotion and WhatsApp messaging

## Testing
- `node -c app.js && node -c builder.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdc8295820832193e9c748d3d351b4