### PR TITLE
feat: improve slot count controls

### DIFF
--- a/builder.css
+++ b/builder.css
@@ -44,24 +44,13 @@
   margin-bottom: .5rem;
 }
 
-.slot-input {
-  display: flex;
-  align-items: center;
-  gap: .25rem;
-}
-
-.slot-input input {
-  width: 4rem;
-  text-align: center;
-}
-
-.slot-input button {
-  padding: .25rem .5rem;
-  border-radius: .25rem;
-  border: 1px solid var(--acento);
-  background: transparent;
-  cursor: pointer;
-}
+.slot-control{ display:flex; align-items:center; gap:8px; }
+.slot-control #slotCount{ width:88px; text-align:center; }
+.btn-step{ width:40px; height:40px; border-radius:10px; border:1px solid var(--suave,#EAC7BD); background:#fff; font-weight:800; cursor:pointer; }
+.btn-step:disabled{ opacity:.5; cursor:not-allowed; }
+.slot-hint{ margin-top:6px; font-size:.9rem; color:var(--oscuro,#5D4036); opacity:.85; }
+.btn-step:focus,
+#slotCount:focus{ outline:2px solid var(--acento); outline-offset:2px; }
 
 #bracelet-color {
   display: flex;
@@ -274,6 +263,13 @@
   0% { transform: scale(1); }
   50% { transform: scale(1.1); }
   100% { transform: scale(1); }
+}
+
+.bracelet-grid.grid-bounce{ animation:grid-bounce .25s ease; }
+@keyframes grid-bounce{
+  0%{transform:scale(1);}
+  50%{transform:scale(1.03);}
+  100%{transform:scale(1);}
 }
 
 @media(max-width:768px){

--- a/builder.html
+++ b/builder.html
@@ -49,11 +49,12 @@
       </div>
       <div class="size-select">
         <label for="slotCount">Eslabones</label>
-        <div class="slot-input">
-          <button id="slotMinus" aria-label="Menos eslabones">-</button>
-          <input type="number" id="slotCount" min="10" max="24" step="1" value="18">
-          <button id="slotPlus" aria-label="Más eslabones">+</button>
+        <div class="slot-control" role="group" aria-label="Selector de eslabones">
+          <button type="button" id="slotMinus" class="btn-step" aria-label="Disminuir eslabones">–</button>
+          <input type="number" id="slotCount" min="10" max="24" step="1" value="18" inputmode="numeric" aria-live="polite" />
+          <button type="button" id="slotPlus" class="btn-step" aria-label="Aumentar eslabones">+</button>
         </div>
+        <div id="slotHint" class="slot-hint" aria-live="polite"></div>
       </div>
       <fieldset id="bracelet-color" class="color-select" aria-label="Color de pulsera">
         <label><input type="radio" name="braceletColor" value="plata" checked><span>Plata</span></label>


### PR DESCRIPTION
## Summary
- Add accessible stepper controls for slot count with min/max validation and hints
- Style slot controls and add subtle grid bounce animation
- Persist slot count and update undo/redo logic

## Testing
- `node --check builder.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf9db1b0883219c6f1436d6e5c4ec