### PR TITLE
Add jewelry carousels with beam intro

### DIFF
--- a/data/jewels.json
+++ b/data/jewels.json
@@ -1,0 +1,39 @@
+{
+  "white": [
+    "joya-white- (1).jpeg",
+    "joya-white- (2).jpeg",
+    "joya-white- (3).jpeg",
+    "joya-white- (4).jpeg",
+    "joya-white- (5).jpeg",
+    "joya-white- (6).jpeg",
+    "joya-white- (7).jpeg",
+    "joya-white- (8).jpeg",
+    "joya-white- (9).jpeg",
+    "joya-white- (10).jpeg",
+    "joya-white- (11).jpeg",
+    "joya-white- (12).jpeg",
+    "joya-white- (13).jpeg",
+    "joya-white- (14).jpeg",
+    "joya-white- (15).jpeg",
+    "joya-white- (16).jpeg"
+  ],
+  "black": [
+    "joya-black- (1).jpeg",
+    "joya-black- (2).jpeg",
+    "joya-black- (3).jpeg",
+    "joya-black- (4).jpeg",
+    "joya-black- (5).jpeg",
+    "joya-black- (6).jpeg",
+    "joya-black- (7).jpeg",
+    "joya-black- (8).jpeg",
+    "joya-black- (9).jpeg",
+    "joya-black- (10).jpeg",
+    "joya-black- (11).jpeg",
+    "joya-black- (12).jpeg",
+    "joya-black- (13).jpeg",
+    "joya-black- (14).jpeg",
+    "joya-black- (15).jpeg",
+    "joya-black- (16).jpeg",
+    "joya-black- (17).jpeg"
+  ]
+}

--- a/joyeria.css
+++ b/joyeria.css
@@ -1,0 +1,47 @@
+:root{
+  --terracota:#C2644C;
+  --acento:#D6A77A;
+  --fondo:#FFF7F2;
+  --suave:#EAC7BD;
+  --oscuro:#5D4036;
+}
+
+.joyeria{ padding: 48px 24px; background: var(--fondo); }
+.joyeria .title{ font-family: "Playfair Display", serif; font-size: clamp(28px,4vw,40px); color: var(--oscuro); text-align:center; margin-bottom: 24px; }
+.joyeria .subtitle{ font-family: "Playfair Display", serif; font-size: clamp(22px,3vw,28px); color: var(--terracota); margin: 24px 0 12px; text-align:center; }
+.joyeria .carousel{ position:relative; }
+.joyeria .track{ display:grid; grid-auto-flow: column; grid-auto-columns: calc((100% - 32px*2) / 3); gap: 32px; overflow:hidden; scroll-snap-type: x mandatory; }
+@media (max-width:1024px){ .joyeria .track{ grid-auto-columns: calc((100% - 24px) / 2); gap:24px; } }
+@media (max-width:640px){ .joyeria .track{ grid-auto-columns: 100%; gap:16px; } }
+.joyeria .card{ scroll-snap-align: start; background:#fff; border-radius:16px; padding:14px; box-shadow:0 10px 30px rgba(0,0,0,.08); border:1px solid rgba(0,0,0,.04); transition: transform .25s ease, box-shadow .25s ease; }
+.joyeria .card:hover{ transform: translateY(-3px); box-shadow:0 16px 36px rgba(0,0,0,.10); }
+.joyeria .card .thumb{
+  width: 260px;
+  height: 260px;
+  object-fit: cover;
+  border-radius: 12px;
+  display:block;
+  margin: 0 auto;
+  box-shadow: 0 6px 20px rgba(0,0,0,.10);
+}
+@media (max-width:640px){ .joyeria .card .thumb{ width: 100%; height: 64vw; max-height: 300px; } }
+.joyeria .nav{ position:absolute; top:50%; transform:translateY(-50%); background:#fff; border:1px solid var(--suave); color:var(--terracota); width:40px; height:40px; border-radius:50%; display:grid; place-items:center; cursor:pointer; box-shadow:0 4px 16px rgba(0,0,0,.08); }
+.joyeria .nav.prev{ left:-12px; }
+.joyeria .nav.next{ right:-12px; }
+.joyeria .nav:hover{ background:var(--fondo); }
+.joyeria .nav:focus{ outline:2px solid var(--acento); outline-offset:2px; }
+.joyeria .dots{ display:flex; gap:8px; justify-content:center; margin-top:12px; }
+.joyeria .dots button{ width:8px; height:8px; border-radius:50%; border:0; background:#e3d4cc; }
+.joyeria .dots button[aria-current="true"]{ background:var(--terracota); }
+.joyeria .beam-intro{
+  pointer-events:none; position: fixed; inset:0; z-index: 5;
+  background:
+    radial-gradient(1200px 400px at 50% -10%, rgba(255,255,255,.45), rgba(255,255,255,0) 60%),
+    linear-gradient(180deg, rgba(255,247,242,.7), rgba(255,247,242,0) 40%);
+  opacity:0; animation: beamEnter 1200ms ease-out forwards;
+}
+@keyframes beamEnter{
+  0%{ opacity:0; transform: translateY(-12px); filter: blur(8px); }
+  40%{ opacity:1; transform: translateY(0); filter: blur(0); }
+  100%{ opacity:0; }
+}

--- a/joyeria.html
+++ b/joyeria.html
@@ -11,8 +11,9 @@
   <link rel="icon" type="image/png" href="img/logos/favicon.png">
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;700&family=Forum&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="joyeria.css">
 </head>
-<body data-category="joyeria">
+<body>
   <header class="header">
     <div class="nav-container container">
       <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
@@ -42,40 +43,31 @@
     <a class="chip" href="firstdate.html">First Date</a>
   </nav>
 
-  <main class="container catalog-page">
-    <aside class="sidebar">
-      <h3>Filtros</h3>
-      <input type="search" id="search" class="search" placeholder="Buscar...">
-      <h4>Categorías</h4>
-      <div id="tag-filter">
-        <span class="chip" data-tag="collar">Collar</span>
-        <span class="chip" data-tag="anillo">Anillo</span>
-        <span class="chip" data-tag="pulsera">Pulsera</span>
-      </div>
-      <h4>Precio</h4>
-      <input type="range" id="price" min="0" max="5000" value="5000">
-      <div class="price-output">$0 - $<span id="price-value">5000</span></div>
-      <label><input type="checkbox" id="available"> Disponible</label>
-    </aside>
-    <section class="catalog-content">
-      <div class="toolbar">
-        <div class="count"><span id="count"></span> productos</div>
-        <div>
-          <select id="sort">
-            <option value="">Ordenar</option>
-            <option value="price-asc">Precio ↑</option>
-            <option value="price-desc">Precio ↓</option>
-            <option value="new">Nuevo</option>
-            <option value="top">Más vendido</option>
-          </select>
-          <div class="view">
-            <button class="chip active" data-view="3">3</button>
-            <button class="chip" data-view="4">4</button>
-          </div>
+  <main>
+    <section class="joyeria">
+      <h1 class="title">Nuestra Joyería</h1>
+
+      <div class="beam-intro" aria-hidden="true"></div>
+
+      <section class="carousel-block">
+        <h2 class="subtitle">Colección White</h2>
+        <div class="carousel" id="carousel-white" aria-roledescription="carousel" aria-label="Colección White" tabindex="0">
+          <button class="nav prev" aria-label="Anterior">‹</button>
+          <div class="track" role="list"></div>
+          <button class="nav next" aria-label="Siguiente">›</button>
         </div>
-      </div>
-      <div id="product-grid" class="grid-3"></div>
-      <div class="pagination"><a href="#" class="chip">1</a></div>
+        <div class="dots" id="dots-white" aria-label="Paginación"></div>
+      </section>
+
+      <section class="carousel-block">
+        <h2 class="subtitle">Colección Black</h2>
+        <div class="carousel" id="carousel-black" aria-roledescription="carousel" aria-label="Colección Black" tabindex="0">
+          <button class="nav prev" aria-label="Anterior">‹</button>
+          <div class="track" role="list"></div>
+          <button class="nav next" aria-label="Siguiente">›</button>
+        </div>
+        <div class="dots" id="dots-black" aria-label="Paginación"></div>
+      </section>
     </section>
   </main>
 
@@ -85,7 +77,7 @@
     </div>
   </footer>
 
-  <dialog id="quick-view" class="glass"></dialog>
   <script src="app.js"></script>
+  <script src="joyeria.js"></script>
 </body>
 </html>

--- a/joyeria.js
+++ b/joyeria.js
@@ -1,0 +1,67 @@
+async function loadJewels(){
+  try{
+    const res = await fetch('/data/jewels.json');
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    return await res.json();
+  }catch(err){
+    console.error('No se pudo cargar listado de joyería', err);
+    return { white: [], black: [] };
+  }
+}
+
+function renderCarousel(trackEl, dotsEl, files){
+  trackEl.innerHTML = files.map(f=>{
+    const src = `/img/joyeria/${f}`;
+    const alt = f.replace('.jpeg','').replace(/-/g,' ');
+    return `<figure class="card" role="listitem">
+              <img class="thumb" src="${src}" alt="${alt}" loading="lazy">
+            </figure>`;
+  }).join('');
+  setupCarousel(trackEl, dotsEl);
+}
+
+function setupCarousel(track, dots){
+  let index = 0;
+  const pageSize = () => {
+    if (window.matchMedia('(max-width:640px)').matches) return 1;
+    if (window.matchMedia('(max-width:1024px)').matches) return 2;
+    return 3;
+  };
+  const pages = Math.ceil(track.children.length / pageSize());
+  const prevBtn = track.parentElement.querySelector('.prev');
+  const nextBtn = track.parentElement.querySelector('.next');
+
+  function goTo(i){
+    index = (i + pages) % pages;
+    const x = index * track.clientWidth;
+    track.scrollTo({ left: x, behavior: 'smooth' });
+    [...dots.children].forEach((d, k)=> d.setAttribute('aria-current', k===index ? 'true' : 'false'));
+  }
+
+  dots.innerHTML = Array.from({length: pages})
+    .map((_,i)=>`<button aria-label="Ir a la página ${i+1}" ${i===0?'aria-current="true"':''}></button>`).join('');
+  dots.addEventListener('click', e=>{
+    if (e.target.tagName==='BUTTON'){
+      const i=[...dots.children].indexOf(e.target);
+      goTo(i);
+    }
+  });
+
+  prevBtn?.addEventListener('click', ()=>goTo(index-1));
+  nextBtn?.addEventListener('click', ()=>goTo(index+1));
+
+  track.parentElement.addEventListener('keydown', e=>{
+    if (e.key==='ArrowLeft') goTo(index-1);
+    if (e.key==='ArrowRight') goTo(index+1);
+  });
+
+  window.addEventListener('resize', ()=>setupCarousel(track, dots), { once:true });
+
+  goTo(0);
+}
+
+document.addEventListener('DOMContentLoaded', async ()=>{
+  const data = await loadJewels();
+  renderCarousel(document.querySelector('#carousel-white .track'), document.getElementById('dots-white'), data.white || []);
+  renderCarousel(document.querySelector('#carousel-black .track'), document.getElementById('dots-black'), data.black || []);
+});


### PR DESCRIPTION
## Summary
- Replace jewelry page with two carousels for White and Black collections
- Add beam intro animation and responsive carousel styles
- Load image lists from new data/jewels.json via joyeria.js

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be1634eb988321b61d5a079a117c50