### PR TITLE
feat: unify destacados section with auto-rotating cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,61 +50,50 @@
       <p class="intro-text">Somos Arturo y Enrique, diseñando experiencias y detalles que enamoran. Creemos en los gestos que dibujan una sonrisa al corazón: más que ropa o joyas, creamos momentos. Explora nuestro catálogo, descubre lo que estamos creando y sorprende a esa persona especial con algo que cuente su historia.</p>
     </section>
 
-    <section class="featured">
-      <h2>Destacados</h2>
+    <section class="destacados">
+      <h2 class="destacados-title">Destacados</h2>
 
-      <div class="featured-carousel">
-        <h3>Ropa</h3>
-        <div class="slider">
-          <button class="slider-btn prev" aria-label="Anterior">&#10094;</button>
-          <div class="slider-track">
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-ropa-01.jpeg" alt="Destacado ropa 01"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-ropa-02.jpeg" alt="Destacado ropa 02"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-ropa-03.jpeg" alt="Destacado ropa 03"></div></div>
+      <div class="destacados-grid">
+        <!-- Ropa -->
+        <a class="destacada-card rotator" href="/ropa.html"
+           aria-label="Ver destacados de Ropa"
+           data-images="/img/destacados/destacado-ropa-01.jpeg,/img/destacados/destacado-ropa-02.jpeg,/img/destacados/destacado-ropa-03.jpeg">
+          <div class="media">
+            <img alt="Ropa destacada" loading="lazy" decoding="async" />
           </div>
-          <button class="slider-btn next" aria-label="Siguiente">&#10095;</button>
-        </div>
-      </div>
+          <h3>Ropa</h3>
+        </a>
 
-      <div class="featured-carousel">
-        <h3>Joyería</h3>
-        <div class="slider">
-          <button class="slider-btn prev" aria-label="Anterior">&#10094;</button>
-          <div class="slider-track">
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-joya-01.jpeg" alt="Destacado joyería 01"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-joya-02.jpeg" alt="Destacado joyería 02"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-joya-03.jpeg" alt="Destacado joyería 03"></div></div>
+        <!-- Joyería -->
+        <a class="destacada-card rotator" href="/joyeria.html"
+           aria-label="Ver destacados de Joyería"
+           data-images="/img/destacados/destacado-joya-01.jpeg,/img/destacados/destacado-joya-02.jpeg,/img/destacados/destacado-joya-03.jpeg">
+          <div class="media">
+            <img alt="Joyería destacada" loading="lazy" decoding="async" />
           </div>
-          <button class="slider-btn next" aria-label="Siguiente">&#10095;</button>
-        </div>
-      </div>
+          <h3>Joyería</h3>
+        </a>
 
-      <div class="featured-carousel">
-        <h3>Charms</h3>
-        <div class="slider">
-          <button class="slider-btn prev" aria-label="Anterior">&#10094;</button>
-          <div class="slider-track">
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-charm-01.png" alt="Destacado charms 01"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-charm-02.png" alt="Destacado charms 02"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-charm-03.png" alt="Destacado charms 03"></div></div>
+        <!-- Charms -->
+        <a class="destacada-card rotator" href="/charms.html"
+           aria-label="Ver destacados de Charms"
+           data-images="/img/destacados/destacado-charm-01.png,/img/destacados/destacado-charm-02.png,/img/destacados/destacado-charm-03.png">
+          <div class="media">
+            <img alt="Charms destacados" loading="lazy" decoding="async" />
           </div>
-          <button class="slider-btn next" aria-label="Siguiente">&#10095;</button>
-        </div>
-      </div>
+          <h3>Charms</h3>
+        </a>
 
-      <div class="featured-carousel">
-        <h3>First Date</h3>
-        <div class="slider">
-          <button class="slider-btn prev" aria-label="Anterior">&#10094;</button>
-          <div class="slider-track">
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-firstdate-01.webp" alt="Destacado first date 01"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-firstdate-02.webp" alt="Destacado first date 02"></div></div>
-            <div class="card"><div class="img-wrapper"><img src="img/destacados/destacado-firstdate-03.webp" alt="Destacado first date 03"></div></div>
+        <!-- First Date -->
+        <a class="destacada-card rotator" href="/firstdate.html"
+           aria-label="Ver destacados de First Date"
+           data-images="/img/destacados/destacado-firstdate-01.webp,/img/destacados/destacado-firstdate-02.webp,/img/destacados/destacado-firstdate-03.webp">
+          <div class="media">
+            <img alt="First Date destacado" loading="lazy" decoding="async" />
           </div>
-          <button class="slider-btn next" aria-label="Siguiente">&#10095;</button>
-        </div>
+          <h3>First Date</h3>
+        </a>
       </div>
-
     </section>
   </main>
 
@@ -115,6 +104,7 @@
   </footer>
 
   <dialog id="quick-view" class="glass"></dialog>
+  <script src="/scripts/destacados.js" defer></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/scripts/destacados.js
+++ b/scripts/destacados.js
@@ -1,0 +1,52 @@
+(function(){
+  const INTERVAL = 2000; // 2s
+  const cards = document.querySelectorAll('.rotator');
+
+  // Solo iniciar si está en viewport (mejor rendimiento)
+  const io = new IntersectionObserver((entries)=>{
+    entries.forEach(entry=>{
+      const el = entry.target;
+      if(entry.isIntersecting){
+        start(el);
+      }else{
+        stop(el);
+      }
+    });
+  }, {threshold: .2});
+
+  cards.forEach(card=>{
+    // Primer frame
+    const imgs = getImages(card);
+    const imgEl = card.querySelector('img');
+    imgEl.src = imgs[0];
+    imgEl.dataset.index = '0';
+
+    // Pausa en hover (en desktop)
+    card.addEventListener('mouseenter', ()=> stop(card));
+    card.addEventListener('mouseleave', ()=> start(card));
+
+    // Observar visibilidad
+    io.observe(card);
+  });
+
+  function getImages(card){
+    return card.dataset.images.split(',').map(s=>s.trim()).filter(Boolean);
+  }
+
+  function tick(card){
+    const imgs = getImages(card);
+    const imgEl = card.querySelector('img');
+    const idx = (Number(imgEl.dataset.index||'0') + 1) % imgs.length;
+    imgEl.src = imgs[idx];
+    imgEl.dataset.index = String(idx);
+  }
+
+  function start(card){
+    if(card._timer) return;
+    card._timer = setInterval(()=>tick(card), INTERVAL);
+  }
+
+  function stop(card){
+    if(card._timer){ clearInterval(card._timer); card._timer = null; }
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -155,36 +155,44 @@ a:hover { color:var(--acento); }
 .intro h2{color:var(--principal);}
 .intro-text{max-width:700px;margin:0 auto;}
 
-/* Featured carousels */
-.featured{margin-bottom:96px;}
-@media(max-width:1024px){.featured{margin-bottom:80px;}}
-@media(max-width:600px){.featured{margin-bottom:64px;}}
-.featured-carousel{margin:40px 0;}
-.slider{position:relative;}
-.slider-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;gap:20px;padding-bottom:10px;}
-.slider-track::-webkit-scrollbar{display:none;}
-.slider-track .card{
-  flex:0 0 auto;
-  scroll-snap-align:start;
-  width:400px;
-  max-width:100%;
-  background:none;
-  border:none;
-  border-radius:12px;
-  overflow:hidden;
-  box-shadow:0 4px 10px rgba(0,0,0,.1);
+/* Destacados */
+.destacados{ padding: 32px 16px; background: var(--fondo,#FFF7F2); }
+.destacados-title{
+  font-family:"Playfair Display",serif; color:var(--oscuro,#5D4036);
+  font-size: clamp(22px,3vw,28px); text-align:center; margin-bottom: 16px;
 }
 
-.slider-track .card img{
-  width:100%;
-  height:auto;
-  display:block;
+.destacados-grid{
+  display:grid; grid-template-columns: repeat(4, 1fr); gap: 20px;
 }
-.slider-btn{position:absolute;top:50%;transform:translateY(-50%);background:var(--principal);color:var(--fondo);border:none;width:40px;height:40px;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center;transition:background .3s;}
-.slider-btn:hover{background:var(--acento);}
-.slider-btn.prev{left:-20px;}
-.slider-btn.next{right:-20px;}
-@media(max-width:768px){.slider-btn{display:none;}}
+@media (max-width: 1024px){
+  .destacados-grid{ grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px){
+  .destacados-grid{ grid-template-columns: 1fr; }
+}
+
+.destacada-card{
+  display:block; background:#fff; border:1px solid rgba(0,0,0,.06);
+  border-radius: 16px; text-decoration:none; color:inherit;
+  box-shadow: 0 10px 24px rgba(0,0,0,.06);
+  transition: transform .2s ease, box-shadow .2s ease;
+}
+.destacada-card:hover{ transform: translateY(-3px); box-shadow:0 16px 32px rgba(0,0,0,.1); }
+
+.destacada-card .media{
+  position:relative; width:100%; aspect-ratio: 4/5; /* mismo alto/ancho visual */
+  overflow:hidden; border-radius: 16px 16px 0 0;
+}
+.destacada-card img{
+  width:100%; height:100%; object-fit:cover; display:block;
+}
+
+.destacada-card h3{
+  font-family:"Playfair Display",serif;
+  font-size:1.05rem; text-align:center; padding: 10px 0 14px;
+  color: var(--terracota,#C2644C);
+}
 
 /* Carousel */
 .carousel{position:relative;overflow:hidden;margin:40px auto;max-width:900px;}


### PR DESCRIPTION
## Summary
- replace home destacados section with four auto-rotating cards
- add responsive estilos for new destacados grid
- implement JS rotator for automatic image cycling

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be1a790b5483219088fb89022a4309