### PR TITLE
Improve home hero spacing, carousel fade, and chip icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,41 @@
   </section>
 
   <nav class="categories">
-    <a class="chip" href="ropa.html">Ropa</a>
-    <a class="chip" href="joyeria.html">Joyería</a>
-    <a class="chip" href="charms.html">Charms</a>
-    <a class="chip" href="builder.html">Constructor</a>
-    <a class="chip" href="firstdate.html">First Date</a>
+    <a class="chip" href="ropa.html">
+      <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 10V7a2 2 0 1 1 4 0"/>
+        <path d="M3 16h18l-9-6-9 6"/>
+      </svg>
+      Ropa
+    </a>
+    <a class="chip" href="joyeria.html">
+      <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="13" r="5"/>
+        <path d="M8 2l4 4 4-4"/>
+      </svg>
+      Joyería
+    </a>
+    <a class="chip" href="charms.html">
+      <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 2v4"/>
+        <path d="M12 8l3 3-3 3-3-3z"/>
+      </svg>
+      Charms
+    </a>
+    <a class="chip" href="builder.html">
+      <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10 14l-2 2a3 3 0 1 0 4.24 4.24l2-2"/>
+        <path d="M14 10l2-2a3 3 0 1 0-4.24-4.24l-2 2"/>
+        <path d="M8 12l8-8"/>
+      </svg>
+      Constructor
+    </a>
+    <a class="chip" href="firstdate.html">
+      <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78L12 21.23l8.84-8.84a5.5 5.5 0 0 0 0-7.78z"/>
+      </svg>
+      First Date
+    </a>
   </nav>
 
   <main class="container">

--- a/scripts/destacados.js
+++ b/scripts/destacados.js
@@ -1,6 +1,7 @@
 (function(){
-  const DEFAULT_INTERVAL = 3000; // 3s
-  const FADE = 600; // duración del crossfade en ms
+  const DEFAULT_INTERVAL = 5000; // 5s
+  const FADE = 1200; // duración del crossfade en ms
+  const PREFERS_REDUCED = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   const cards = document.querySelectorAll('.rotator');
 
@@ -21,6 +22,9 @@
     imgEl.src = imgs[0];
     imgEl.dataset.index = '0';
 
+    // preload restantes
+    imgs.slice(1).forEach(src=>{ const i = new Image(); i.src = src; });
+
     // hover pause (desktop)
     card.addEventListener('mouseenter', ()=> stop(card));
     card.addEventListener('mouseleave', ()=> start(card));
@@ -36,33 +40,38 @@
     return (current + 1) % length;
   }
 
-  function crossfadeTo(card, nextSrc){
+  async function crossfadeTo(card, nextSrc){
     const media = card.querySelector('.media');
     const base  = media.querySelector('img');
+    if(card._busy) return;
+    card._busy = true;
 
-    // capa fantasma
     const ghost = base.cloneNode();
     ghost.classList.add('fade-layer');
-    ghost.src = nextSrc;
     ghost.style.opacity = '0';
+    ghost.src = nextSrc;
+
+    const ready = ghost.decode ? ghost.decode() : new Promise(res=>{
+      ghost.onload = ghost.onerror = res;
+    });
+
+    await ready;
     media.appendChild(ghost);
+    requestAnimationFrame(()=>{
+      ghost.style.opacity = '1';
+      base.style.opacity = '0';
+    });
 
-    // fuerza un reflow para que el transition arranque
-    void ghost.offsetWidth;
-
-    // anima
-    ghost.style.opacity = '1';
-    base.style.opacity = '0';
-
-    // al terminar el fade, fijar nuevo src y limpiar
     setTimeout(()=>{
       base.src = nextSrc;
       base.style.opacity = '1';
       ghost.remove();
+      card._busy = false;
     }, FADE);
   }
 
   function tick(card){
+    if(card._busy) return;
     const imgs = getImages(card);
     const base = card.querySelector('img');
     const current = Number(base.dataset.index || '0');
@@ -74,6 +83,7 @@
   }
 
   function start(card){
+    if(PREFERS_REDUCED) return;
     if(card._timer) return;
     const interval = Number(card.dataset.interval || DEFAULT_INTERVAL);
     card._timer = setInterval(()=>tick(card), interval);

--- a/style.css
+++ b/style.css
@@ -47,8 +47,9 @@ a:hover { color:var(--acento); }
 .btn{display:inline-block;margin:10px 0;padding:10px 20px;border-radius:4px;background:var(--principal);color:var(--fondo);transition:background .3s ease;border:none;cursor:pointer;text-align:center;}
 .btn:hover{background:var(--acento);}
 .btn.whatsapp{background:var(--green);}
-.chip{display:inline-block;padding:4px 12px;border-radius:16px;border:1px solid var(--acento);background:var(--fondo);cursor:pointer;font-size:.875rem;transition:.3s;margin:4px;}
+.chip{display:inline-flex;align-items:center;gap:8px;padding:4px 12px;border-radius:16px;border:1px solid var(--acento);background:var(--fondo);cursor:pointer;font-size:.875rem;transition:.3s;margin:4px;color:var(--oscuro);}
 .chip.active,.chip:hover{background:var(--acento);color:var(--fondo);}
+.chip svg{width:20px;height:20px;stroke:currentColor;stroke-width:1.6;fill:none;flex-shrink:0;}
 .chip:focus,.slider-btn:focus{outline:2px solid var(--acento);outline-offset:2px;}
 .badge{position:absolute;top:8px;left:8px;background:var(--principal);color:var(--fondo);padding:2px 8px;border-radius:8px;font-size:.75rem;}
 .badge-descuento{background:var(--acento,#D6A77A);color:#111;font-weight:700;padding:2px 8px;border-radius:999px;}
@@ -124,7 +125,7 @@ a:hover { color:var(--acento); }
 }
 
 /* Hero */
-.hero{height:70vh;background-size:cover;background-position:center;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;margin-top:60px;color:var(--fondo);}
+.hero{height:70vh;background-size:cover;background-position:center;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;margin-top:0;color:var(--fondo);}
 
 .hero::after {
   content:'';
@@ -192,15 +193,21 @@ a:hover { color:var(--acento); }
 .rotator .media img{
   display:block; width:100%; height:100%; object-fit:cover;
   position:relative; z-index:1;
-  transition:opacity .6s ease;
+  transition:opacity 1.2s ease-in-out;
+  will-change:opacity; backface-visibility:hidden; transform:translateZ(0);
 }
 .rotator .media .fade-layer{
   position:absolute; inset:0;
   width:100%; height:100%; object-fit:cover;
   opacity:0; z-index:2;
-  transition:opacity .6s ease;
-  pointer-events:none;
-  border-radius:inherit;
+  transition:opacity 1.2s ease-in-out;
+  pointer-events:none; border-radius:inherit;
+  will-change:opacity; backface-visibility:hidden; transform:translateZ(0);
+}
+
+@media (prefers-reduced-motion:reduce){
+  .rotator .media img,
+  .rotator .media .fade-layer{transition:none;}
 }
 
 .destacada-card h3{


### PR DESCRIPTION
## Summary
- Remove extra gap so hero sits flush under sticky header
- Smooth featured card carousel with 5s interval, 1.2s crossfade, and preloaded images
- Add inline line-style icons to category chips and adjust chip styling

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68be5f2be21083218d46f401613164e9