### PR TITLE
feat: restore bracelet builder and integrate UI

### DIFF
--- a/builder.css
+++ b/builder.css
@@ -309,3 +309,4 @@
 }
 
 #braceletHero{margin-bottom:12px;}
+#bracelet-color[hidden]{display:none;}

--- a/builder.html
+++ b/builder.html
@@ -57,7 +57,7 @@
         </div>
         <div id="slotHint" class="slot-hint" aria-live="polite"></div>
       </div>
-      <fieldset id="bracelet-color" class="color-select" aria-label="Color de pulsera">
+      <fieldset id="bracelet-color" class="color-select" aria-label="Color de pulsera" hidden>
         <label><input type="radio" name="braceletColor" value="plata" checked><span>Plata</span></label>
         <label><input type="radio" name="braceletColor" value="dorado"><span>Dorado</span></label>
         <label><input type="radio" name="braceletColor" value="negro"><span>Negro</span></label>
@@ -82,7 +82,7 @@
     <aside class="bracelet-area">
       <h2>Tu Pulsera</h2>
       <div id="braceletHero" class="bracelet-preview" data-color="plata"></div>
-      <div id="bracelet" class="bracelet-grid" aria-live="polite"></div>
+      <div id="braceletView" class="bracelet-grid" aria-live="polite"></div>
       <p id="bracelet-status"></p>
       <p id="bracelet-total" class="price"></p>
       <p id="bracelet-promo" class="promo-note"></p>
@@ -97,8 +97,8 @@
     <button id="clear" aria-label="Vaciar">Vaciar</button>
       <button id="save" aria-label="Guardar">Guardar</button>
       <button id="load" aria-label="Cargar">Cargar</button>
-      <button id="download" aria-label="Descargar imagen del diseño (mock)">Descargar imagen del diseño (mock)</button>
-      <button id="whatsapp" aria-label="Pedir por WhatsApp" class="whatsapp">Pedir por WhatsApp</button>
+      <button id="exportPng" aria-label="Descargar imagen del diseño (mock)">Descargar imagen del diseño (mock)</button>
+      <button id="whatsappBtn" aria-label="Pedir por WhatsApp" class="whatsapp">Pedir por WhatsApp</button>
     </div>
 
   <footer class="footer">

--- a/builder.js
+++ b/builder.js
@@ -17,24 +17,24 @@ const baseCharms = {
     name: 'Eslabón liso',
     price: 0,
     isBase: true,
-    imgFront: '/img/pulsera/link-plata.png',
-    imgBack: '/img/pulsera/link-plata.png'
+    imgFront: '/img/pulsera-plata.webp',
+    imgBack: '/img/pulsera-plata.webp'
   },
   dorado: {
     id: 'base-dorado',
     name: 'Eslabón liso',
     price: 0,
     isBase: true,
-    imgFront: '/img/pulsera/link-dorado.png',
-    imgBack: '/img/pulsera/link-dorado.png'
+    imgFront: '/img/pulsera-dorado.webp',
+    imgBack: '/img/pulsera-dorado.webp'
   },
   negro: {
     id: 'base-negro',
     name: 'Eslabón liso',
     price: 0,
     isBase: true,
-    imgFront: '/img/pulsera/link-negro.png',
-    imgBack: '/img/pulsera/link-negro.png'
+    imgFront: '/img/pulsera-negro.webp',
+    imgBack: '/img/pulsera-negro.webp'
   }
 };
 
@@ -125,7 +125,7 @@ function rebuildBraceletGrid(size){
 }
 
 function animateGridBounce(){
-  const grid=document.getElementById('bracelet');
+  const grid=document.getElementById('braceletView');
   if(grid){
     grid.classList.add('grid-bounce');
     setTimeout(()=>grid.classList.remove('grid-bounce'),300);
@@ -173,21 +173,22 @@ function addCharm(id, index){
   if(index === -1) return;
   slots[index] = id;
   pushState();
-  renderBracelet();
+  renderSlot(index);
   updateTotals();
 }
 
 function removeCharm(index){
   slots[index] = getBaseId(braceletColor);
   pushState();
-  renderBracelet();
+  renderSlot(index);
   updateTotals();
 }
 
 function swapSlots(a,b){
   [slots[a], slots[b]] = [slots[b], slots[a]];
   pushState();
-  renderBracelet();
+  renderSlot(a);
+  renderSlot(b);
   updateTotals();
 }
 
@@ -196,7 +197,7 @@ function setBraceletColor(color){
   localStorage.setItem('auren.braceletColor',braceletColor);
   slots=slots.map(id=>isBase(id)?getBaseId(color):id);
   pushState();
-  renderBracelet();
+  for(let i=0;i<braceletSize;i++) renderSlot(i);
   const hero=document.getElementById('braceletHero');
   if(hero) hero.dataset.color=braceletColor;
   updateTotals();
@@ -254,13 +255,17 @@ function renderCatalog(){
   list.forEach((c,i)=>{
     const out=c.stock<=0;
     const card=document.createElement('div');card.className='charm-card fade-in';card.dataset.id=c.id;
+    card.tabIndex=0;
+    card.setAttribute('aria-label',c.name);
     if(out) card.classList.add('out'); else card.draggable=true;
     card.style.animationDelay=`${i*50}ms`;
     const priceHTML=`<div class="price"><span class="price-old">$${c.priceOriginal}</span><span class="price-new">$${c.price}</span></div>`;
-    card.innerHTML=`<img src="${c.imgFront}" alt="${c.name} frente" class="front"><img src="${c.imgBack}" alt="${c.name} reverso" class="back"><h4>${c.name}</h4>${priceHTML}${c.badge?`<span class="badge badge-descuento">${c.badge}</span>`:''}${out?`<span class="badge agotado">Agotado</span>`:''}<button class="add"${out?' disabled':''}>Agregar</button>`;
+    card.innerHTML=`<img src="${c.imgFront}" alt="${c.name} frente" class="front" loading="lazy"><img src="${c.imgBack}" alt="${c.name} reverso" class="back" loading="lazy"><h4>${c.name}</h4>${priceHTML}${c.badge?`<span class=\"badge badge-descuento\">${c.badge}</span>`:''}${out?`<span class=\"badge agotado\">Agotado</span>`:''}<button class="add"${out?' disabled':''} aria-label="Agregar ${c.name}">Agregar</button>`;
     if(!out){
       card.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/plain',c.id);});
-      card.querySelector('.add').addEventListener('click',()=>addCharm(c.id));
+      const addBtn=card.querySelector('.add');
+      addBtn.addEventListener('click',()=>addCharm(c.id));
+      card.addEventListener('keydown',e=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();addCharm(c.id);}});
     }
     catalog.appendChild(card);
   });
@@ -268,51 +273,70 @@ function renderCatalog(){
 }
 
 function renderBracelet(){
-  const container=document.getElementById('bracelet');
+  const container=document.getElementById('braceletView');
   container.innerHTML='';
-  for(let i=0;i<braceletSize;i++){
-    const slot=document.createElement('div');
-    slot.className='slot fade-in';
-    slot.style.animationDelay=`${i*50}ms`;
-    slot.dataset.index=i;
-    slot.textContent=String(i+1).padStart(2,'0');
-    slot.addEventListener('dragover',e=>e.preventDefault());
-    slot.addEventListener('drop',handleDrop);
-    if(slots[i]){
-      const charm=getCharm(slots[i]);
-      if(charm){
-        const color = charm.id.split('-')[1];
-        if(charm.isBase){
-          const colorName=color.charAt(0).toUpperCase()+color.slice(1);
-          slot.classList.add('filled','base',charm.id);
-          slot.title=`Eslabón liso (${colorName})`;
-          slot.innerHTML=`<img src="${charm.imgFront}" alt="Eslabón liso (${colorName})" onerror="this.style.display='none';this.parentElement.classList.add('no-img');">`;
-        }else{
-          slot.classList.add('filled');
-          slot.innerHTML=`<img src="${charm.imgFront}" alt="${charm.name}">`;
-          const rm=document.createElement('button');rm.className='remove';rm.textContent='x';rm.addEventListener('click',()=>removeCharm(i));slot.appendChild(rm);
-          if(charm.stock<=0){
-            slot.classList.add('out');
-            const warn=document.createElement('span');warn.className='badge agotado';warn.textContent='Agotado';slot.appendChild(warn);
-          }
-          slot.draggable=true;
-          slot.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/slot',i);});
-          let startX=null;
-          slot.addEventListener('touchstart',e=>{startX=e.touches[0].clientX;});
-          slot.addEventListener('touchend',e=>{
-            if(startX===null) return;
-            const dx=e.changedTouches[0].clientX-startX;
-            if(Math.abs(dx)>30){
-              if(dx<0 && i<braceletSize-1) swapSlots(i,i+1);
-              else if(dx>0 && i>0) swapSlots(i,i-1);
-            }
-            startX=null;
-          });
+  for(let i=0;i<braceletSize;i++) renderSlot(i);
+}
+
+function slotKeyHandler(e){
+  const i=parseInt(e.currentTarget.dataset.index,10);
+  if((e.key==='Delete' || e.key==='Backspace') && !isBase(slots[i])){ e.preventDefault(); removeCharm(i); }
+  if(e.key==='ArrowLeft' && i>0){ e.preventDefault(); swapSlots(i,i-1); document.querySelector(`.slot[data-index="${i-1}"]`).focus(); }
+  if(e.key==='ArrowRight' && i<braceletSize-1){ e.preventDefault(); swapSlots(i,i+1); document.querySelector(`.slot[data-index="${i+1}"]`).focus(); }
+}
+
+function renderSlot(i){
+  const container=document.getElementById('braceletView');
+  const existing=container.querySelector(`.slot[data-index="${i}"]`);
+  const slot=document.createElement('div');
+  slot.className='slot fade-in';
+  slot.style.animationDelay=`${i*50}ms`;
+  slot.dataset.index=i;
+  slot.tabIndex=0;
+  slot.textContent=String(i+1).padStart(2,'0');
+  slot.setAttribute('aria-label',`Slot ${i+1}`);
+  slot.addEventListener('dragover',e=>e.preventDefault());
+  slot.addEventListener('drop',handleDrop);
+  slot.addEventListener('keydown',slotKeyHandler);
+  if(slots[i]){
+    const charm=getCharm(slots[i]);
+    if(charm){
+      const color = charm.id.split('-')[1];
+      if(charm.isBase){
+        const colorName=color.charAt(0).toUpperCase()+color.slice(1);
+        slot.classList.add('filled','base',charm.id);
+        slot.title=`Eslabón liso (${colorName})`;
+        slot.innerHTML=`<img src="${charm.imgFront}" alt="Eslabón liso (${colorName})" onerror="this.style.display='none';this.parentElement.classList.add('no-img');">`;
+      }else{
+        slot.classList.add('filled');
+        slot.innerHTML=`<img src="${charm.imgFront}" alt="${charm.name}">`;
+        const rm=document.createElement('button');
+        rm.className='remove';
+        rm.textContent='x';
+        rm.setAttribute('aria-label','Quitar charm');
+        rm.addEventListener('click',()=>removeCharm(i));
+        slot.appendChild(rm);
+        if(charm.stock<=0){
+          slot.classList.add('out');
+          const warn=document.createElement('span');warn.className='badge agotado';warn.textContent='Agotado';slot.appendChild(warn);
         }
+        slot.draggable=true;
+        slot.addEventListener('dragstart',e=>{e.dataTransfer.setData('text/slot',i);});
+        let startX=null;
+        slot.addEventListener('touchstart',e=>{startX=e.touches[0].clientX;});
+        slot.addEventListener('touchend',e=>{
+          if(startX===null) return;
+          const dx=e.changedTouches[0].clientX-startX;
+          if(Math.abs(dx)>30){
+            if(dx<0 && i<braceletSize-1) swapSlots(i,i+1);
+            else if(dx>0 && i>0) swapSlots(i,i-1);
+          }
+          startX=null;
+        });
       }
     }
-    container.appendChild(slot);
   }
+  if(existing) container.replaceChild(slot, existing); else container.appendChild(slot);
 }
 
 function triggerSnap(index){
@@ -337,7 +361,8 @@ function handleDrop(e){
       slots[targetIndex]=slots[from];
       slots[from]=getBaseId(braceletColor);
       pushState();
-      renderBracelet();
+      renderSlot(targetIndex);
+      renderSlot(from);
       updateTotals();
       triggerSnap(targetIndex);
     }
@@ -349,11 +374,13 @@ function handleDrop(e){
       slots[targetIndex]=charmId;
       const empty=firstEmptySlot();
       if(empty!==-1) slots[empty]=temp;
+      renderSlot(targetIndex);
+      if(empty!==-1) renderSlot(empty);
     }else{
       slots[targetIndex]=charmId;
+      renderSlot(targetIndex);
     }
     pushState();
-    renderBracelet();
     updateTotals();
     triggerSnap(targetIndex);
   }
@@ -367,12 +394,24 @@ function updateTotals(){
   document.getElementById('bracelet-total').textContent=`Total: $${total}`;
   document.getElementById('bracelet-status').textContent=`Eslabones: ${braceletSize} | Color: ${colorName} | Eslabones lisos: ${baseCount}`;
   const promo=document.getElementById('bracelet-promo');
-  if(promo){promo.textContent=total>=400?'Pulsera incluida GRATIS':'';}
+  if(promo){promo.textContent=total>=400?'Pulsera gratis':'';}
 }
 
 function saveLocal(){
-  localStorage.setItem('auren-bracelet',JSON.stringify({slotCount:braceletSize,color:braceletColor,slots}));
+  const filters={...getFilters(),compact:document.getElementById('compact').checked};
+  localStorage.setItem('auren-bracelet',JSON.stringify({slotCount:braceletSize,color:braceletColor,slots,filters}));
   localStorage.setItem('auren.braceletColor',braceletColor);
+}
+
+function applyFilters(filters={}){
+  document.getElementById('search').value=filters.search||'';
+  document.getElementById('price-min').value=filters.min||document.getElementById('price-min').min;
+  document.getElementById('price-max').value=filters.max||document.getElementById('price-max').max;
+  document.getElementById('sort').value=filters.sort||'relevance';
+  document.getElementById('compact').checked=filters.compact||false;
+  document.querySelectorAll('#filter-tags button').forEach(b=>b.classList.toggle('active',filters.tags?.includes(b.dataset.tag)));
+  document.querySelectorAll('#filter-color button').forEach(b=>b.classList.toggle('active',filters.colors?.includes(b.dataset.color)));
+  document.querySelectorAll('#filter-material button').forEach(b=>b.classList.toggle('active',filters.materials?.includes(b.dataset.material)));
 }
 
 function loadLocal(){
@@ -383,6 +422,9 @@ function loadLocal(){
     braceletColor=obj.color || braceletColor;
     localStorage.setItem('auren.braceletColor',braceletColor);
     slots=obj.slots || [];
+    applyFilters(obj.filters||{});
+    updatePriceDisplay();
+    renderCatalog();
   }
   slots.length=braceletSize;
   for(let i=0;i<braceletSize;i++){
@@ -390,8 +432,6 @@ function loadLocal(){
     if(!id || !getCharm(id) || isBase(id)) slots[i]=getBaseId(braceletColor);
   }
   if(slotCountEl) slotCountEl.value=braceletSize;
-  const colorRadio=document.querySelector(`input[name="braceletColor"][value="${braceletColor}"]`);
-  if(colorRadio) colorRadio.checked=true;
   const hero=document.getElementById('braceletHero');
   if(hero) hero.dataset.color=braceletColor;
   renderBracelet();
@@ -429,27 +469,27 @@ function sendWhatsApp(){
   }).filter(Boolean).join('%0A');
   const total=slots.filter(id=>!isBase(id)).reduce((s,id)=>s+(getCharm(id)?.price||0),0);
   const baseCount=slots.filter(id=>isBase(id)).length;
-  const promo=total>=400? '%0APromo aplicada: pulsera GRATIS':'';
+  const promo=total>=400? '%0APromo aplicada: Pulsera gratis':'';
   const msg=`Hola Auren, quiero esta pulsera italiana:%0AEslabones: ${braceletSize}%0AColor de pulsera: ${colorName}%0A${lines}${lines?'%0A':''}Eslabones lisos: ${baseCount}%0ASubtotal charms: $${total}${promo}%0ATotal a pagar: $${total}%0A¿Opciones de pago, por favor?`;
   window.open(`https://wa.me/523142836428?text=${msg}`,'_blank');
 }
 
 // Descargar imagen del diseño
 async function downloadMock(){
-  const filled=slots.filter(id=>!isBase(id));
-  if(!filled.length){
+  if(slots.every(id=>isBase(id))){
     alert('No hay charms en tu diseño');
     return;
   }
-  const cell=100;
-  const cols=6;
-  const rows=Math.ceil(filled.length/cols);
+  const cell=80;
+  const margin=10;
   const canvas=document.createElement('canvas');
-  canvas.width=cols*cell;
-  canvas.height=rows*cell;
+  canvas.width=braceletSize*cell + margin*2;
+  canvas.height=cell + margin*2;
   const ctx=canvas.getContext('2d');
+  ctx.fillStyle='#fff';
+  ctx.fillRect(0,0,canvas.width,canvas.height);
 
-  const images=await Promise.all(filled.map(id=>{
+  const images=await Promise.all(slots.map(id=>{
     const c=getCharm(id);
     return new Promise((resolve,reject)=>{
       const img=new Image();
@@ -460,9 +500,8 @@ async function downloadMock(){
   }));
 
   images.forEach((img,i)=>{
-    const x=(i%cols)*cell;
-    const y=Math.floor(i/cols)*cell;
-    ctx.drawImage(img,x,y,cell,cell);
+    const x=margin + i*cell;
+    ctx.drawImage(img,x,margin,cell,cell);
   });
 
   const link=document.createElement('a');
@@ -490,6 +529,7 @@ function redo(){
 // Event bindings
 window.addEventListener('DOMContentLoaded',async()=>{
   charms = await charmsPromise;
+  charms.forEach(c=>{const img=new Image();img.src=c.imgFront;});
   renderFilters();
   renderCatalog();
   const params=new URLSearchParams(location.search);
@@ -505,6 +545,9 @@ window.addEventListener('DOMContentLoaded',async()=>{
       braceletSize=saved.slotCount;
       slots=saved.slots || [];
       if(!colorParam && !localStorage.getItem('auren.braceletColor') && saved.color) braceletColor=saved.color;
+      applyFilters(saved.filters||{});
+      updatePriceDisplay();
+      renderCatalog();
     }
     slots.length=braceletSize;
     for(let i=0;i<braceletSize;i++){
@@ -515,8 +558,6 @@ window.addEventListener('DOMContentLoaded',async()=>{
   slots=slots.map(id=>isBase(id)?getBaseId(braceletColor):id);
   localStorage.setItem('auren.braceletColor',braceletColor);
   if(slotCountEl) slotCountEl.value=braceletSize;
-  const colorRadio=document.querySelector(`input[name="braceletColor"][value="${braceletColor}"]`);
-  if(colorRadio) colorRadio.checked=true;
   const hero=document.getElementById('braceletHero');
   if(hero) hero.dataset.color=braceletColor;
   applySlotCount(Number(slotCountEl.value),{from:'init'});
@@ -525,14 +566,13 @@ window.addEventListener('DOMContentLoaded',async()=>{
   document.getElementById('price-max').addEventListener('input',()=>{updatePriceDisplay();renderCatalog();});
   document.getElementById('sort').addEventListener('change',renderCatalog);
   document.getElementById('compact').addEventListener('change',renderCatalog);
-  document.querySelectorAll('input[name="braceletColor"]').forEach(r=>r.addEventListener('change',e=>setBraceletColor(e.target.value)));
   document.getElementById('undo').addEventListener('click',undo);
   document.getElementById('redo').addEventListener('click',redo);
   document.getElementById('clear').addEventListener('click',()=>{if(confirm('¿Vaciar pulsera?')){slots=Array(braceletSize).fill(getBaseId(braceletColor));pushState();renderBracelet();updateTotals();}});
   document.getElementById('save').addEventListener('click',saveLocal);
   document.getElementById('load').addEventListener('click',loadLocal);
-  document.getElementById('download').addEventListener('click',downloadMock);
-  document.getElementById('whatsapp').addEventListener('click',sendWhatsApp);
+  document.getElementById('exportPng').addEventListener('click',downloadMock);
+  document.getElementById('whatsappBtn').addEventListener('click',sendWhatsApp);
   const filterToggle=document.getElementById('filter-toggle');
   const filters=document.querySelector('.filters');
   const overlay=document.getElementById('filter-overlay');


### PR DESCRIPTION
## Summary
- reinstate bracelet builder with responsive catalog, slots and promo logic
- add keyboard accessibility, undo/redo, and local storage for filters
- prepare bracelet color hook and export/WhatsApp actions

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf1bef41348321ab5fd2a4ef02f6e7