### PR TITLE
Restore bracelet builder with relative assets and cache busting

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ let braceletColor = localStorage.getItem('auren.braceletColor') || 'plata';
 
 async function loadCharmsCatalog(){
   try{
-    const res=await fetch('/data/charms.json');
+    const res=await fetch('data/charms.json');
     if(!res.ok) throw new Error('HTTP '+res.status);
     charmsCatalog=await res.json();
   }catch(err){

--- a/assets/css/builder.css
+++ b/assets/css/builder.css
@@ -38,6 +38,13 @@
   margin-bottom: .5rem;
 }
 
+.build-info {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  opacity: 0.7;
+}
+
 .chips {
   display: flex;
   flex-wrap: wrap;

--- a/assets/js/builder.js
+++ b/assets/js/builder.js
@@ -1,7 +1,7 @@
 // Constructor de Pulsera Italiana
 // Merge resuelto: incluye slots editables y selector de color de pulsera
 let charms = [];
-const charmsPromise = fetch('/data/charms.json')
+const charmsPromise = fetch('./data/charms.json')
   .then(r => { if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); })
   .catch(err => {
     console.warn('No se pudo cargar catálogo de charms, usando fallback.', err);
@@ -17,24 +17,24 @@ const baseCharms = {
     name: 'Eslabón liso',
     price: 0,
     isBase: true,
-    imgFront: '/img/pulsera-plata.webp',
-    imgBack: '/img/pulsera-plata.webp'
+    imgFront: 'img/pulsera-plata.webp',
+    imgBack: 'img/pulsera-plata.webp'
   },
   dorado: {
     id: 'base-dorado',
     name: 'Eslabón liso',
     price: 0,
     isBase: true,
-    imgFront: '/img/pulsera-dorado.webp',
-    imgBack: '/img/pulsera-dorado.webp'
+    imgFront: 'img/pulsera-dorado.webp',
+    imgBack: 'img/pulsera-dorado.webp'
   },
   negro: {
     id: 'base-negro',
     name: 'Eslabón liso',
     price: 0,
     isBase: true,
-    imgFront: '/img/pulsera-negro.webp',
-    imgBack: '/img/pulsera-negro.webp'
+    imgFront: 'img/pulsera-negro.webp',
+    imgBack: 'img/pulsera-negro.webp'
   }
 };
 

--- a/builder.html
+++ b/builder.html
@@ -9,7 +9,10 @@
   <link rel="icon" type="image/png" href="img/logos/favicon.png">
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;700&family=Forum&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="builder.css">
+  <script>
+    const BUILDER_VERSION = Date.now();
+    document.write(`<link rel="stylesheet" href="./assets/css/builder.css?v=${BUILDER_VERSION}">`);
+  </script>
 </head>
 <body id="bracelet-builder">
   <header class="header">
@@ -104,10 +107,16 @@
   <footer class="footer">
     <div class="container">
       <p>&copy; 2025 Auren - Arturo & Enrique</p>
+      <small id="build-info" class="build-info"></small>
     </div>
   </footer>
 
   <script src="app.js"></script>
-  <script src="builder.js"></script>
+  <script>
+    document.write(`<script src="./assets/js/builder.js?v=${BUILDER_VERSION}"><\\/script>`);
+    console.log('Builder loaded @ ' + BUILDER_VERSION);
+    const info=document.getElementById('build-info');
+    if(info) info.textContent='Build '+new Date(BUILDER_VERSION).toLocaleString();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -85,9 +85,9 @@
 
       <div class="destacados-grid">
         <!-- Ropa -->
-        <a class="destacada-card rotator" href="/ropa.html"
+        <a class="destacada-card rotator" href="ropa.html"
            aria-label="Ver destacados de Ropa"
-           data-images="/img/destacados/destacado-ropa-01.jpeg,/img/destacados/destacado-ropa-02.jpeg,/img/destacados/destacado-ropa-03.jpeg">
+             data-images="img/destacados/destacado-ropa-01.jpeg,img/destacados/destacado-ropa-02.jpeg,img/destacados/destacado-ropa-03.jpeg">
           <div class="media">
             <img alt="Ropa destacada" loading="lazy" decoding="async" />
           </div>
@@ -95,9 +95,9 @@
         </a>
 
         <!-- Joyería -->
-        <a class="destacada-card rotator" href="/joyeria.html"
+        <a class="destacada-card rotator" href="joyeria.html"
            aria-label="Ver destacados de Joyería"
-           data-images="/img/destacados/destacado-joya-01.jpeg,/img/destacados/destacado-joya-02.jpeg,/img/destacados/destacado-joya-03.jpeg">
+             data-images="img/destacados/destacado-joya-01.jpeg,img/destacados/destacado-joya-02.jpeg,img/destacados/destacado-joya-03.jpeg">
           <div class="media">
             <img alt="Joyería destacada" loading="lazy" decoding="async" />
           </div>
@@ -105,9 +105,9 @@
         </a>
 
         <!-- Charms -->
-        <a class="destacada-card rotator" href="/charms.html"
+        <a class="destacada-card rotator" href="charms.html"
            aria-label="Ver destacados de Charms"
-           data-images="/img/destacados/destacado-charm-01.png,/img/destacados/destacado-charm-02.png,/img/destacados/destacado-charm-03.png">
+             data-images="img/destacados/destacado-charm-01.png,img/destacados/destacado-charm-02.png,img/destacados/destacado-charm-03.png">
           <div class="media">
             <img alt="Charms destacados" loading="lazy" decoding="async" />
           </div>
@@ -115,9 +115,9 @@
         </a>
 
         <!-- First Date -->
-        <a class="destacada-card rotator" href="/firstdate.html"
+        <a class="destacada-card rotator" href="firstdate.html"
            aria-label="Ver destacados de First Date"
-           data-images="/img/destacados/destacado-firstdate-01.webp,/img/destacados/destacado-firstdate-02.webp,/img/destacados/destacado-firstdate-03.webp">
+             data-images="img/destacados/destacado-firstdate-01.webp,img/destacados/destacado-firstdate-02.webp,img/destacados/destacado-firstdate-03.webp">
           <div class="media">
             <img alt="First Date destacado" loading="lazy" decoding="async" />
           </div>
@@ -134,7 +134,7 @@
   </footer>
 
   <dialog id="quick-view" class="glass"></dialog>
-  <script src="/scripts/destacados.js" defer></script>
+  <script src="scripts/destacados.js" defer></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- relocate builder CSS/JS into assets with cache-busting versioning
- switch builder scripts and home page links to relative paths for GitHub Pages
- expose build timestamp in builder footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check assets/js/builder.js`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf2d9d19f88321bfd97036b3481d7c