### PR TITLE
feat(marketing): banner elegante UGC con persistencia y CTAs a Instagram/Facebook

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ document.addEventListener('DOMContentLoaded',async()=>{
   initMenu();
   initSliders();
   initPromoBar();
+  initSocialBanner();
   const bodyCategory=document.body.dataset.category;
   if(bodyCategory) initCatalog(bodyCategory);
   if(document.getElementById('product-detail')) initProductPage();
@@ -103,6 +104,54 @@ function initPromoBar(){
   }
 
   show();
+}
+
+function initSocialBanner(){
+  const banner=document.getElementById('promoSocialBanner');
+  if(!banner) return;
+  const close=document.getElementById('bannerClose');
+  const storageKey='promoSocialBanner.dismissedAt';
+  const dismissed=parseInt(localStorage.getItem(storageKey)||0,10);
+  const now=Date.now();
+  if(dismissed && now-dismissed < 7*24*60*60*1000){
+    banner.remove();
+    return;
+  }
+  function show(){
+    banner.classList.add('social-banner--enter');
+    const promoH=document.body.classList.contains('promo-bar-visible')?parseInt(getComputedStyle(document.body).getPropertyValue('--promo-bar-height')||'0',10):0;
+    banner.style.top=promoH+'px';
+    const height=banner.offsetHeight;
+    document.body.style.setProperty('--social-banner-height',height+'px');
+    document.body.classList.add('social-banner-visible');
+    requestAnimationFrame(()=>{
+      banner.classList.replace('social-banner--enter','social-banner--visible');
+    });
+  }
+  function hide(){
+    banner.classList.replace('social-banner--visible','social-banner--exit');
+    banner.addEventListener('transitionend',e=>{
+      if(e.propertyName==='opacity') banner.remove();
+    },{once:true});
+    document.body.classList.remove('social-banner-visible');
+    localStorage.setItem(storageKey,Date.now().toString());
+  }
+  setTimeout(show,400);
+  if(close){
+    close.addEventListener('click',hide);
+    close.addEventListener('keydown',e=>{
+      if(e.key==='Enter'||e.key===' '){
+        e.preventDefault();
+        hide();
+      }
+    });
+  }
+  banner.querySelectorAll('a').forEach(a=>{
+    a.addEventListener('click',()=>{
+      const cta=a.id==='ctaInstagram'?'instagram':a.id==='ctaFacebook'?'facebook':'howto';
+      console.log('bannerSocial',{cta});
+    });
+  });
 }
 
 function initCatalog(category){

--- a/cupon.html
+++ b/cupon.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cómo canjear tu cupón - Auren</title>
+  <link rel="icon" type="image/png" href="img/logos/favicon.png">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;700&family=Forum&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="header">
+    <div class="nav-container container">
+      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
+      <nav>
+        <ul class="nav-links">
+          <li><a href="ropa.html">Ropa</a></li>
+          <li><a href="joyeria.html">Joyería</a></li>
+          <li><a href="charms.html">Charms</a></li>
+          <li><a href="builder.html">Constructor</a></li>
+          <li><a href="firstdate.html">First Date</a></li>
+        </ul>
+        <button class="hamburger" aria-label="Menú">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>Cómo canjear tu cupón</h1>
+    <ol>
+      <li>Sube una foto pública de tu compra.</li>
+      <li>Etiquétanos en Instagram <strong>@arturoyenrique</strong> o en Facebook <strong>auren</strong>.</li>
+      <li>Envíanos el enlace o número de orden por WhatsApp o mediante nuestro formulario.</li>
+    </ol>
+    <p>Aplican términos y condiciones. Descuento hasta 50% según reglas vigentes.</p>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>&copy; 2025 Auren - Arturo & Enrique</p>
+    </div>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         </ul>
         <button class="hamburger" aria-label="Menú">&#9776;</button>
       </nav>
-    </div>
+  </div>
   </header>
 
   <div id="promoBar" class="promo-bar promo-bar--hidden" role="region" aria-label="Promoción" aria-live="polite">
@@ -34,6 +34,22 @@
       <span class="promo-bar__icon" aria-hidden="true">🎁</span>
       <span class="promo-bar__text promo-bar__text--underline">Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</span>
       <button class="promo-bar__close" aria-label="Cerrar promoción">✕</button>
+    </div>
+  </div>
+
+  <div id="promoSocialBanner" class="social-banner" role="region" aria-label="Promoción de cupón por redes sociales">
+    <div class="social-banner__content">
+      <span class="social-banner__icon" aria-hidden="true">📸</span>
+      <div class="social-banner__text" aria-live="polite">
+        <span class="social-banner__title">Comparte tu compra y gana 🎉</span>
+        <span class="social-banner__subtitle">Sube una foto de tu compra y etiquétenos: @arturoyenrique en Instagram o “auren” en Facebook. ¡Obtén un cupón para tu próxima compra de hasta 50% de descuento!</span>
+      </div>
+      <div class="social-banner__actions">
+        <a id="ctaInstagram" class="btn" href="https://instagram.com/arturoyenrique?utm_source=site&utm_medium=banner&utm_campaign=ugc-cupon" target="_blank" rel="noopener">Instagram</a>
+        <a id="ctaFacebook" class="btn" href="https://facebook.com/auren?utm_source=site&utm_medium=banner&utm_campaign=ugc-cupon" target="_blank" rel="noopener">Facebook</a>
+        <a id="ctaHowTo" class="btn" href="cupon.html" target="_blank" rel="noopener">Cómo canjear</a>
+      </div>
+      <button id="bannerClose" class="social-banner__close" aria-label="Cerrar anuncio">✕</button>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -114,6 +114,44 @@ body.promo-bar-visible .header{margin-top:var(--promo-bar-height);transition:mar
   body.promo-bar-visible .header{transition:margin-top .2s ease;}
 }
 .promo-note{color:var(--principal);font-weight:700;}
+
+/* Social Banner */
+.social-banner{
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  background:var(--acento,#D6A77A);
+  color:#111;
+  padding:8px 16px;
+  z-index:1100;
+  box-shadow:0 2px 4px rgba(0,0,0,.08);
+  border-radius:0 0 8px 8px;
+  opacity:0;
+  transform:translateY(-8px);
+  transition:opacity .3s ease,transform .3s ease;
+}
+.social-banner__content{max-width:1200px;margin:0 auto;display:flex;align-items:center;gap:8px;flex-wrap:wrap;}
+.social-banner__icon{font-size:1rem;}
+.social-banner__text{flex:1;display:flex;flex-direction:column;font-size:.85rem;gap:2px;}
+.social-banner__actions{display:flex;gap:8px;}
+.social-banner__actions .btn{margin:0;}
+.social-banner__close{background:none;border:none;cursor:pointer;width:44px;height:44px;display:flex;align-items:center;justify-content:center;border-radius:4px;color:inherit;}
+.social-banner__close:focus{outline:2px solid var(--oscuro);outline-offset:2px;}
+.social-banner--enter{opacity:0;transform:translateY(-8px);}
+.social-banner--visible{opacity:1;transform:translateY(0);}
+.social-banner--exit{opacity:0;transform:translateY(-8px);}
+body.social-banner-visible .header{margin-top:var(--social-banner-height);transition:margin-top .3s ease;}
+body.promo-bar-visible.social-banner-visible .header{margin-top:calc(var(--promo-bar-height)+var(--social-banner-height));}
+@media(max-width:600px){
+  .social-banner__text{font-size:.8rem;}
+  .social-banner__actions .btn{padding:6px 12px;font-size:.8rem;margin:0;}
+}
+@media(prefers-reduced-motion:reduce){
+  .social-banner{transition:opacity .2s ease;transform:none;}
+  .social-banner--enter,.social-banner--visible,.social-banner--exit{transform:none;}
+  body.social-banner-visible .header{transition:margin-top .2s ease;}
+}
 .card{position:relative;background:rgba(255,247,242,.8);border:1px solid var(--suave);border-radius:16px;overflow:hidden;box-shadow:0 4px 10px rgba(0,0,0,.08);transition:transform .3s;}
 .card:hover{transform:translateY(-4px);}
 .card .img-wrapper{position:relative;overflow:hidden;}


### PR DESCRIPTION
## Summary
- add social banner under header inviting users to compartir su compra y ganar
- style responsive `.social-banner` component
- add JS logic for show/hide with 7-day persistence and tracking
- new `cupon.html` with instructions to redeem coupon

## Testing
- `node --check app.js`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c061e05b208321bf93aad5f0c2de5c