### PR TITLE
feat(ui): unify hero across pages + shared header/footer + official email

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,20 @@ let products=[];
 let braceletColor = localStorage.getItem('auren.braceletColor') || 'plata';
 let socialConfig={}; /* AUREN: config social global */
 
+// AUREN: carga de header y footer
+async function injectPartials(){
+  const [h,f]=await Promise.all([
+    fetch('/partials/header.html').then(r=>r.text()),
+    fetch('/partials/footer.html').then(r=>r.text())
+  ]);
+  document.querySelector('#site-header')?.replaceWith(
+    Object.assign(document.createElement('div'),{id:'site-header',innerHTML:h})
+  );
+  document.querySelector('#site-footer')?.replaceWith(
+    Object.assign(document.createElement('div'),{id:'site-footer',innerHTML:f})
+  );
+}
+
 async function loadCharmsCatalog(){
   try{
     const res=await fetch('data/charms.json');
@@ -73,7 +87,7 @@ function applyWhatsAppCTAs(){
 }
 
 document.addEventListener('DOMContentLoaded',async()=>{
-  await Promise.all([loadCharmsCatalog(), loadSocialConfig()]); /* AUREN: carga inicial */
+  await Promise.all([injectPartials(),loadCharmsCatalog(),loadSocialConfig()]); /* AUREN: carga inicial */
   renderFooterSocials(document.getElementById('auren-socials'));
   applyWhatsAppCTAs();
   initMenu();

--- a/builder.html
+++ b/builder.html
@@ -9,31 +9,16 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="page-builder">
-  <header class="header">
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+  <div id="site-header"></div>
+
+  <section class="hero"></section>
 
   <main class="container">
     <h1>Constructor de Pulsera</h1>
     <div id="builder-root"></div>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <script src="app.js"></script>
   <script src="assets/js/builder.js"></script>

--- a/charms.html
+++ b/charms.html
@@ -11,21 +11,9 @@
   <link rel="stylesheet" href="assets/css/charms.css">
 </head>
 <body class="page-charms">
-  <header class="header">
-    <div class="promo-banner"><a href="charms.html">🎁 Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</a></div>
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+  <div id="site-header"></div>
+
+  <section class="hero"></section>
 
   <main class="container">
     <div class="calculadora">
@@ -79,11 +67,7 @@
     </div>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <script src="app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>

--- a/cupon.html
+++ b/cupon.html
@@ -8,22 +8,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;700&family=Forum&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header class="header">
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="builder.html">Constructor</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+<body class="page-coupon">
+  <div id="site-header"></div>
+
+  <section class="hero"></section>
 
   <main class="container">
     <h1>Cómo canjear tu cupón</h1>
@@ -35,11 +23,7 @@
     <p>Aplican términos y condiciones. Descuento hasta 50% según reglas vigentes.</p>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <script src="app.js"></script>
 </body>

--- a/firstdate.html
+++ b/firstdate.html
@@ -13,27 +13,9 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="page-first">
-  <header class="header">
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="builder.html">Constructor</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+  <div id="site-header"></div>
 
-  <section class="hero" style="background-image:url('img/heroes/hero-02.jpg');">
-    <div class="hero-content">
-      <img src="img/logos/logotipo.png" alt="Auren logotipo" class="logo-hero">
-    </div>
-  </section>
+  <section class="hero" style="background-image:url('img/heroes/hero-02.jpg');"></section>
 
   <nav class="categories">
     <a class="chip" href="ropa.html">Ropa</a>
@@ -74,11 +56,7 @@
     </section>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <dialog id="quick-view" class="glass"></dialog>
   <script src="app.js"></script>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     "contactPoint": {
       "@type": "ContactPoint",
       "contactType": "customer service",
-      "email": "contacto@auren.mx"
+      "email": "auren@arturoyenrique.com"
     },
     "address": {
       "@type": "PostalAddress",
@@ -42,23 +42,7 @@
   </script>
 </head>
 <body class="page-home">
-  <!-- AUREN: Navbar fijo y responsive -->
-  <header class="header site-header">
-    <div class="nav-wrapper container">
-      <a href="index.html" class="logo"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header" loading="lazy" decoding="async"></a>
-      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false">&#9776;</button>
-      <nav class="nav" aria-label="principal">
-        <ul class="nav-menu">
-          <li><a href="index.html">Inicio</a></li>
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-          <li><a href="#contacto">Contacto</a></li>
-        </ul>
-      </nav>
-    </div>
-  </header>
+  <div id="site-header"></div>
 
   <!-- AUREN: Barra de promoción reutilizada -->
   <div id="promoBar" class="promo-bar promo-bar--hidden" role="region" aria-label="Promoción" aria-live="polite">
@@ -229,28 +213,7 @@
   </main>
 
   <!-- AUREN: Footer con información de contacto -->
-  <footer class="footer" id="contacto">
-    <div class="container footer-grid">
-      <div>
-        <h3>Contacto</h3>
-        <p><a data-cta="whatsapp" class="link">WhatsApp</a></p> <!-- AUREN: CTA dinámico -->
-        <p><a href="mailto:contacto@auren.mx" class="link">contacto@auren.mx</a></p>
-        <p>Manzanillo, MX</p>
-      </div>
-      <div>
-        <h3>Redes sociales</h3>
-        <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-      </div>
-      <div>
-        <h3>Legal</h3>
-        <ul class="legal-links">
-          <li><a href="#" class="link">Aviso de privacidad</a></li>
-          <li><a href="#" class="link">Términos y condiciones</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="footer-bottom">&copy; 2025 Auren. Todos los derechos reservados.</div>
-  </footer>
+  <div id="site-footer"></div>
 
   <dialog id="quick-view" class="glass"></dialog>
   <script src="scripts/destacados.js" defer></script>

--- a/joyeria.html
+++ b/joyeria.html
@@ -14,27 +14,9 @@
   <link rel="stylesheet" href="joyeria.css">
 </head>
 <body class="page-joyeria">
-  <header class="header">
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="builder.html">Constructor</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+  <div id="site-header"></div>
 
-  <section class="hero" style="background-image:url('img/heroes/hero-04.jpg');">
-    <div class="hero-content">
-      <img src="img/logos/logotipo.png" alt="Auren logotipo" class="logo-hero">
-    </div>
-  </section>
+  <section class="hero" style="background-image:url('img/heroes/hero-04.jpg');"></section>
 
   <nav class="categories">
     <a class="chip" href="ropa.html">Ropa</a>
@@ -71,11 +53,7 @@
     </section>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <script src="app.js"></script>
   <script src="joyeria.js"></script>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,22 @@
+<footer class="footer" id="contacto">
+  <div class="container footer-grid">
+    <div>
+      <h3>Contacto</h3>
+      <p><a data-cta="whatsapp" class="link">WhatsApp</a></p>
+      <p><a href="mailto:auren@arturoyenrique.com" class="link" rel="noopener">auren@arturoyenrique.com</a></p>
+      <p>Manzanillo, MX</p>
+    </div>
+    <div>
+      <h3>Redes sociales</h3>
+      <div id="auren-socials" class="footer-social"></div>
+    </div>
+    <div>
+      <h3>Legal</h3>
+      <ul class="legal-links">
+        <li><a href="#" class="link">Aviso de privacidad</a></li>
+        <li><a href="#" class="link">Términos y condiciones</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer-bottom">&copy; 2025 Auren. Todos los derechos reservados.</div>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,17 @@
+<header class="header site-header">
+  <div class="nav-wrapper container">
+    <a href="index.html" class="logo"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header" loading="lazy" decoding="async"></a>
+    <button class="hamburger" aria-label="Abrir menú" aria-expanded="false">&#9776;</button>
+    <nav class="nav" aria-label="principal">
+      <ul class="nav-menu">
+        <li><a href="index.html">Inicio</a></li>
+        <li><a href="ropa.html">Ropa</a></li>
+        <li><a href="joyeria.html">Joyería</a></li>
+        <li><a href="charms.html">Charms</a></li>
+        <li><a href="builder.html">Constructor</a></li>
+        <li><a href="firstdate.html">First Date</a></li>
+        <li><a href="#contacto">Contacto</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/producto.html
+++ b/producto.html
@@ -12,23 +12,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;700&family=Forum&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
-<body id="product-detail">
-  <header class="header">
-    <div class="promo-banner"><a href="builder.html">🎁 Promo: en la compra de $400 MXN en charms, tu pulsera es GRATIS.</a></div>
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="builder.html">Constructor</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+<body id="product-detail" class="page-product">
+  <div id="site-header"></div>
+
+  <section class="hero"></section>
 
   <main class="container product">
     <div class="product-gallery">
@@ -61,11 +48,7 @@
     <div id="related" class="grid-4"></div>
   </section>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <dialog id="quick-view" class="glass"></dialog>
   <script src="app.js"></script>

--- a/ropa.html
+++ b/ropa.html
@@ -10,21 +10,9 @@
   <link rel="stylesheet" href="ropa.css">
 </head>
 <body class="page-ropa" data-category="ropa">
-  <header class="header">
-    <div class="nav-container container">
-      <a href="index.html" class="brand"><img src="img/logos/isotipo.png" alt="Auren" class="logo-header"></a>
-      <nav>
-        <ul class="nav-links">
-          <li><a href="ropa.html" class="active">Ropa</a></li>
-          <li><a href="joyeria.html">Joyería</a></li>
-          <li><a href="charms.html">Charms</a></li>
-          <li><a href="builder.html">Constructor</a></li>
-          <li><a href="firstdate.html">First Date</a></li>
-        </ul>
-        <button class="hamburger" aria-label="Menú">&#9776;</button>
-      </nav>
-    </div>
-  </header>
+  <div id="site-header"></div>
+
+  <section class="hero"></section>
 
   <main class="container">
     <h1>Colección AUREN · Ropa</h1>
@@ -51,11 +39,7 @@
     <div id="sentinel"></div>
   </main>
 
-  <footer class="footer">
-    <div class="container">
-      <div id="auren-socials" class="footer-social"></div> <!-- AUREN: footer social -->
-    </div>
-  </footer>
+  <div id="site-footer"></div>
 
   <div class="qv" role="dialog" aria-modal="true" aria-labelledby="qv-title">
     <div class="qv__backdrop" onclick="closeQuickView()"></div>

--- a/style.css
+++ b/style.css
@@ -11,6 +11,8 @@
   --auren-surface:#5D4036; /* AUREN: bordes */
   --ring:#D6A77A; /* AUREN: foco accesible */
   --green:#25D366; /* AUREN: color WhatsApp */
+  --hero-logo-tint:#D6A77A; /* AUREN: default (joyería) */
+  --hero-logo-opacity:.10;
   /* AUREN: variables legacy para compatibilidad */
   --bg:var(--auren-bg);
   --text:var(--auren-text);
@@ -41,13 +43,14 @@ body {
   line-height:1.6;
 }
 
-/* AUREN: page color tokens */
-.page-home{--hero-logo-tint:var(--auren-gold);--hero-logo-opacity:.15;}
-.page-charms{--hero-logo-tint:var(--auren-primary);--hero-logo-opacity:.12;}
-.page-joyeria{--hero-logo-tint:var(--auren-gold);--hero-logo-opacity:.18;}
-.page-ropa{--hero-logo-tint:var(--auren-soft);--hero-logo-opacity:.12;}
-.page-first{--hero-logo-tint:var(--auren-primary);--hero-logo-opacity:.18;}
-.page-builder{--hero-logo-tint:var(--auren-gold);--hero-logo-opacity:.1;}
+/* AUREN: tokens de tinte para imagotipo */
+.page-home   { --hero-logo-tint:#C2644C; --hero-logo-opacity:.12; }
+.page-charms { --hero-logo-tint:#D6A77A; --hero-logo-opacity:.12; }
+.page-ropa   { --hero-logo-tint:#EAC7BD; --hero-logo-opacity:.12; }
+.page-first  { --hero-logo-tint:#C2644C; --hero-logo-opacity:.11; }
+.page-builder{ --hero-logo-tint:#FFF7F2; --hero-logo-opacity:.09; }
+.page-product{ --hero-logo-tint:#D6A77A; --hero-logo-opacity:.10; }
+.page-coupon { --hero-logo-tint:#EAC7BD; --hero-logo-opacity:.11; }
 
 /* AUREN: tokens */
 :root{
@@ -273,26 +276,34 @@ body.promo-bar-visible.social-banner-visible .header{margin-top:calc(var(--promo
 }
 
 /* Hero */
-.hero{height:70vh;background-size:cover;background-position:center;display:flex;align-items:center;justify-content:center;text-align:center;position:relative;margin-top:0;color:var(--auren-text);}/* AUREN: compat hero */
-
-.hero::after{content:'';}/* AUREN: remueve overlay legacy */
-
-.hero-content { position:relative; }
-
-.logo-hero{height:200px;width:auto;display:block;margin:0 auto;opacity:0;transform:scale(.95);animation:fadeZoom 1.5s ease forwards;}
-@media(max-width:1024px){
-  .logo-hero{height:150px;}
+.hero{
+  position:relative;overflow:hidden;isolation:isolate;
+  height:70vh;background-size:cover;background-position:center;
+  display:flex;align-items:center;justify-content:center;text-align:center;
+  margin-top:0;color:var(--auren-text);
 }
-@media(max-width:600px){
-  .logo-hero{height:110px;}
+.hero>*,.hero-slider{position:relative;z-index:1;}
+.hero::after{
+  content:"";position:absolute;inset:0;z-index:0;pointer-events:none;
+  background-repeat:no-repeat;background-position:center;
+  background-size:clamp(280px,38vw,560px);
+  opacity:0;filter:drop-shadow(0 0 28px rgba(0,0,0,.25));mix-blend-mode:screen;
+  --t:var(--hero-logo-tint,#D6A77A);
+  background-image:
+    radial-gradient(circle at 50% 50%,var(--t) 0 70%,transparent 71%),
+    url("/img/logos/imagotipo.png");
+  background-blend-mode:color,normal;
+  animation:aurenHeroIn .9s ease-out forwards;animation-delay:.15s;
+}
+@keyframes aurenHeroIn{
+  0%{opacity:0;transform:scale(.96);}
+  100%{opacity:var(--hero-logo-opacity,.10);transform:scale(1);}
+}
+@media(prefers-reduced-motion:reduce){
+  .hero::after{animation:none;opacity:var(--hero-logo-opacity,.10);}
 }
 
 .categories{display:flex;justify-content:center;gap:10px;margin-top:20px;flex-wrap:wrap;}
-
-@keyframes fadeZoom {
-  from { opacity:0; transform:scale(.9); }
-  to { opacity:1; transform:scale(1); }
-}
 
 /* Intro */
 .intro{padding:60px 20px;text-align:center;}
@@ -455,20 +466,12 @@ main{padding:100px 20px 40px;}
   .nav-menu.open{transform:translateY(0);}
 }
 
-.hero{position:relative;height:100vh;overflow:hidden;color:var(--auren-text);background:var(--auren-bg-deep);}/* AUREN: hero slider */
-/* AUREN: hero imagotipo */
-.hero::before{content:'';position:absolute;inset:0;background-color:var(--hero-logo-tint);mask:url('/img/logos/imagotipo.png') no-repeat center/ clamp(280px,38vw,520px);-webkit-mask:url('/img/logos/imagotipo.png') no-repeat center/ clamp(280px,38vw,520px);opacity:var(--hero-logo-opacity);animation:aurenHeroIn 1.2s ease both;pointer-events:none;mix-blend-mode:luminosity;}
-.hero-slider{position:absolute;inset:0;z-index:0;}
+.hero-slider{position:absolute;inset:0;z-index:1;}
 .hero-slider .slide{position:absolute;inset:0;opacity:0;transition:opacity 1s ease;}/* AUREN: fade coherente */
 .hero-slider .slide img{width:100%;height:100%;object-fit:cover;display:block;}
 .hero-slider .slide.active{opacity:1;}
 .hero-overlay{position:relative;z-index:2;height:100%;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;gap:1rem;background:rgba(58,44,38,.55);padding:0 1rem;}/* AUREN: overlay cálida */
 .hero-ctas{display:flex;gap:1rem;flex-wrap:wrap;justify-content:center;margin-top:1rem;}
-
-@keyframes aurenHeroIn{
-  from{opacity:0;transform:scale(1.05);}
-  to{opacity:var(--hero-logo-opacity);transform:scale(1);}
-}
 
 .destacados{padding:4rem 0;}/* AUREN: sección destacados */
 .destacados-title{text-align:center;margin-bottom:2rem;color:var(--auren-text);}/* AUREN: título sección */


### PR DESCRIPTION
## Summary
- add shared header and footer partials with new official contact info
- centralize hero watermark tint tokens and animation across pages
- inject partials site-wide via app.js and update pages to use unified hero

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run gen:charms`
- `npm run gen:ropa`


------
https://chatgpt.com/codex/tasks/task_e_68c4571f9870832198b95403a1a4d27e