### PR TITLE
feat(social): add follow buttons and social wall via JSON links

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,86 @@ async function loadSocialConfig(){
   }
 }
 
+// AUREN: cargar posts del muro social (el cliente reemplazará los ejemplos del JSON)
+async function loadSocialWall(){
+  const wall=document.getElementById('social-wall');
+  if(!wall) return;
+  try{
+    const res=await fetch('/data/social_posts.json');
+    if(!res.ok) throw new Error('HTTP '+res.status);
+    const data=await res.json();
+    wall.innerHTML='';
+
+    // X/Twitter
+    (data.twitter||[]).slice(0,3).forEach(url=>{
+      const wrap=document.createElement('div');
+      wrap.className='embed-card';
+      wrap.innerHTML=`<blockquote class="twitter-tweet"><a href="${url}"></a></blockquote>`;
+      wall.appendChild(wrap);
+    });
+
+    // TikTok
+    (data.tiktok||[]).slice(0,3).forEach(url=>{
+      const wrap=document.createElement('div');
+      wrap.className='embed-card';
+      wrap.innerHTML=`<blockquote class="tiktok-embed" cite="${url}" data-video-id="" style="max-width: 100%;min-width: 250px;"><section><a href="${url}" target="_blank" rel="noopener">Ver en TikTok</a></section></blockquote>`;
+      wall.appendChild(wrap);
+    });
+
+    // Facebook
+    (data.facebook||[]).slice(0,3).forEach(url=>{
+      const wrap=document.createElement('div');
+      wrap.className='embed-card';
+      wrap.innerHTML=`<div class="fb-post" data-href="${url}" data-width=""></div>`;
+      wall.appendChild(wrap);
+    });
+
+    // Instagram (fallback sin token)
+    (data.instagram||[]).slice(0,3).forEach(url=>{
+      const wrap=document.createElement('div');
+      wrap.className='embed-card';
+      wrap.innerHTML=`
+        <div style="display:grid;gap:8px;">
+          <span style="color:var(--auren-gold);font-weight:600;">Instagram</span>
+          <a class="btn-follow" href="${url}" target="_blank" rel="noopener noreferrer">Abrir publicación</a>
+        </div>`;
+      wall.appendChild(wrap);
+    });
+
+  }catch(err){
+    console.error('AUREN social wall error',err);
+  }finally{
+    loadPlatformScripts();
+  }
+}
+
+function loadPlatformScripts(){
+  // Twitter
+  if(!document.getElementById('twitter-wjs')){
+    const s=document.createElement('script');
+    s.id='twitter-wjs'; s.async=true; s.src='https://platform.twitter.com/widgets.js';
+    document.body.appendChild(s);
+  }
+  // TikTok
+  if(!document.getElementById('tiktok-embed')){
+    const t=document.createElement('script');
+    t.id='tiktok-embed'; t.async=true; t.src='https://www.tiktok.com/embed.js';
+    document.body.appendChild(t);
+  }
+  // Facebook
+  if(!document.getElementById('facebook-jssdk')){
+    if(!document.getElementById('fb-root')){
+      const fb=document.createElement('div');
+      fb.id='fb-root';
+      document.body.appendChild(fb);
+    }
+    const s=document.createElement('script');
+    s.id='facebook-jssdk'; s.async=true;
+    s.src='https://connect.facebook.net/es_LA/sdk.js#xfbml=1&version=v20.0';
+    document.body.appendChild(s);
+  }
+}
+
 function getWhatsappLink(message=''){
   const num=(socialConfig.whatsapp_number_e164||'').replace(/[^0-9]/g,'');
   const base=`https://wa.me/${num}`;
@@ -90,6 +170,7 @@ document.addEventListener('DOMContentLoaded',async()=>{
   await Promise.all([injectPartials(),loadCharmsCatalog(),loadSocialConfig()]); /* AUREN: carga inicial */
   renderFooterSocials(document.getElementById('auren-socials'));
   applyWhatsAppCTAs();
+  loadSocialWall();
   initMenu();
   initSliders();
   initPromoBar();

--- a/data/social_posts.json
+++ b/data/social_posts.json
@@ -1,0 +1,18 @@
+{
+  "instagram": [
+    "https://www.instagram.com/p/XXXXXXXXX/",
+    "https://www.instagram.com/p/YYYYYYYYY/",
+    "https://www.instagram.com/p/ZZZZZZZZZ/"
+  ],
+  "facebook": [
+    "https://www.facebook.com/<PAGE_ID>/posts/<POST_ID>",
+    "https://www.facebook.com/<PAGE_ID>/posts/<POST_ID>"
+  ],
+  "twitter": [
+    "https://twitter.com/auren2025/status/1234567890",
+    "https://twitter.com/auren2025/status/0987654321"
+  ],
+  "tiktok": [
+    "https://www.tiktok.com/@arturoyenrique/video/1234567890"
+  ]
+}

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,3 +1,24 @@
+<section id="social" class="social-section" aria-labelledby="social-title">
+  <div class="container">
+    <h2 id="social-title">Síguenos</h2>
+    <div class="social-actions" aria-label="Acciones de redes">
+      <!-- AUREN: botones oficiales -->
+      <div id="fb-follow">
+        <div class="fb-page" data-href="https://www.facebook.com/profile.php?id=61578576515056" data-tabs="" data-small-header="false" data-adapt-container-width="true" data-hide-cover="false" data-show-facepile="true">
+          <blockquote cite="https://www.facebook.com/profile.php?id=61578576515056" class="fb-xfbml-parse-ignore">
+            <a href="https://www.facebook.com/profile.php?id=61578576515056">Auren</a>
+          </blockquote>
+        </div>
+      </div>
+      <a id="x-follow" href="https://twitter.com/auren2025?ref_src=twsrc%5Etfw" class="btn-follow twitter-follow-button" data-show-count="false" target="_blank" rel="noopener noreferrer" aria-label="Seguir en X (Twitter)">Seguir @auren2025</a>
+      <a id="ig-follow" href="https://www.instagram.com/arturoyenrique/" class="btn-follow" target="_blank" rel="noopener noreferrer" aria-label="Abrir Instagram">Instagram</a>
+      <a id="tt-follow" href="https://www.tiktok.com/@arturoyenrique" class="btn-follow" target="_blank" rel="noopener noreferrer" aria-label="Abrir TikTok">TikTok</a>
+    </div>
+
+    <div class="social-wall" id="social-wall" aria-live="polite"></div>
+  </div>
+</section>
+
 <footer class="footer" id="contacto">
   <div class="container footer-grid">
     <div>

--- a/style.css
+++ b/style.css
@@ -201,6 +201,55 @@ body.promo-bar-visible.social-banner-visible .header{margin-top:calc(var(--promo
   .social-banner--enter,.social-banner--visible,.social-banner--exit{transform:none;}
   body.social-banner-visible .header{transition:margin-top .2s ease;}
 }
+
+/* AUREN: social */
+.social-section{ padding:48px 0 24px; }
+.social-section h2{
+  font-family:"Playfair Display",serif;
+  color:var(--auren-gold);
+  margin-bottom:18px;
+}
+.social-actions{
+  display:flex; flex-wrap:wrap; gap:10px; margin-bottom:16px;
+}
+.btn-follow{
+  display:inline-flex; align-items:center; gap:.5rem;
+  background: var(--auren-card);
+  border: 1px solid rgba(214,167,122,.35);
+  color: var(--auren-text);
+  padding:.55rem .9rem; border-radius:999px;
+  text-decoration:none; transition:transform .2s ease, box-shadow .2s ease, color .2s ease;
+}
+.btn-follow:hover,.btn-follow:focus-visible{
+  transform: translateY(-1px);
+  box-shadow:0 8px 20px rgba(0,0,0,.25);
+  outline:2px solid var(--ring); outline-offset:2px;
+}
+.social-wall{
+  display:grid; gap:22px; grid-template-columns:1fr;
+}
+@media (min-width: 800px){
+  .social-wall{ grid-template-columns: repeat(3,1fr); }
+}
+/* Contenedor de cada embed */
+.embed-card{
+  background: var(--auren-card);
+  border: 1px solid rgba(214,167,122,.35);
+  border-radius: 16px;
+  padding: 10px;
+  box-shadow: 0 10px 24px rgba(0,0,0,.25);
+}
+
+@media (prefers-reduced-motion:reduce){
+  .btn-follow{
+    transition:none;
+  }
+  .btn-follow:hover,
+  .btn-follow:focus-visible{
+    transform:none;
+    box-shadow:none;
+  }
+}
 .card{position:relative;background:rgba(255,247,242,.8);border:1px solid var(--suave);border-radius:16px;overflow:hidden;box-shadow:0 4px 10px rgba(0,0,0,.08);transition:transform .3s;}
 .card:hover{transform:translateY(-4px);}
 .card .img-wrapper{position:relative;overflow:hidden;}


### PR DESCRIPTION
## Summary
- add a reusable "Síguenos" social section with official follow buttons and live region placeholder
- style the section with Auren colors and cards while honouring reduced-motion preferences
- fetch social links from `data/social_posts.json`, render platform embeds, and load required SDKs

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8667f36588321abcc2374f0733c41